### PR TITLE
Cleanup of 2 readme files only different in case (to make OSX happy)...

### DIFF
--- a/tests/test_contracts/old_versions/v1.2.1/eosio.system/Readme.txt
+++ b/tests/test_contracts/old_versions/v1.2.1/eosio.system/Readme.txt
@@ -1,3 +1,0 @@
-Compiled with
-eosio.contracts: bf28f8bbf9ee753966c95c586906e82d72f9dfac (v1.2.1)
-eosio.wasmsdk:   2c106a018f2e69d34325ef2376cf085426068e93, CORE_SYMBOL_NAME = "SYS"


### PR DESCRIPTION
## Change Description
Deleted tests/test_contracts/old_versions/v1.2.1/eosio.system/`Readme.txt` and left `README.txt`

## Deployment Changes
- [ ] Deployment Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
