### PR TITLE
Fix tests to be compatable with Mandel

### DIFF
--- a/.github/workflows/ubuntu-2004.yml
+++ b/.github/workflows/ubuntu-2004.yml
@@ -24,7 +24,7 @@ jobs:
           mkdir build
           ${DOCKER} bash -c "cd build && cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=yes .."
           echo =====
-          ${DOCKER} bash -c "cd build && make -j $(nproc)"
+          ${DOCKER} bash -c "cd build && make -j $(nproc) VERBOSE=1"
           echo =====
           tar -pczf build.tar.gz build
           echo =====

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required( VERSION 3.5 )
 
 set(EOSIO_VERSION_MIN "2.0")
-set(EOSIO_VERSION_SOFT_MAX "2.0")
+set(EOSIO_VERSION_SOFT_MAX "3.0")
 #set(EOSIO_VERSION_HARD_MAX "")
 
 find_package(eosio)

--- a/tests/eosio.limitauth_tests.cpp
+++ b/tests/eosio.limitauth_tests.cpp
@@ -14,15 +14,15 @@
 
 using namespace eosio_system;
 
-inline const auto owner = N(owner);
-inline const auto active = N(active);
-inline const auto admin = N(admin);
-inline const auto admin2 = N(admin2);
-inline const auto freebie = N(freebie);
-inline const auto freebie2 = N(freebie2);
+inline const auto owner = "owner"_n;
+inline const auto active = "active"_n;
+inline const auto admin = "admin"_n;
+inline const auto admin2 = "admin2"_n;
+inline const auto freebie = "freebie"_n;
+inline const auto freebie2 = "freebie2"_n;
 
-inline const auto alice = N(alice1111111);
-inline const auto bob = N(bob111111111);
+inline const auto alice = "alice1111111"_n;
+inline const auto bob = "bob111111111"_n;
 
 struct limitauth_tester: eosio_system_tester {
    action_result push_action(name code, name action, permission_level auth, const variant_object& data) {
@@ -37,7 +37,7 @@ struct limitauth_tester: eosio_system_tester {
 
    action_result limitauthchg(permission_level pl, const name& account, const std::vector<name>& allow_perms, const std::vector<name>& disallow_perms) {
       return push_action(
-         config::system_account_name, N(limitauthchg), pl,
+         config::system_account_name, "limitauthchg"_n, pl,
          mvo()("account", account)("allow_perms", allow_perms)("disallow_perms", disallow_perms));
    }
 
@@ -68,22 +68,22 @@ struct limitauth_tester: eosio_system_tester {
 
    action_result updateauth(permission_level pl, name account, name permission, name parent, authority auth) {
       return push_action_raw(
-         config::system_account_name, N(updateauth), pl, account, permission, parent, auth);
+         config::system_account_name, "updateauth"_n, pl, account, permission, parent, auth);
    }
 
    action_result deleteauth(permission_level pl, name account, name permission) {
       return push_action_raw(
-         config::system_account_name, N(deleteauth), pl, account, permission);
+         config::system_account_name, "deleteauth"_n, pl, account, permission);
    }
 
    action_result linkauth(permission_level pl, name account, name code, name type, name requirement) {
       return push_action_raw(
-         config::system_account_name, N(linkauth), pl, account, code, type, requirement);
+         config::system_account_name, "linkauth"_n, pl, account, code, type, requirement);
    }
 
    action_result unlinkauth(permission_level pl, name account, name code, name type) {
       return push_action_raw(
-         config::system_account_name, N(unlinkauth), pl, account, code, type);
+         config::system_account_name, "unlinkauth"_n, pl, account, code, type);
    }
 
    /////////////
@@ -91,22 +91,22 @@ struct limitauth_tester: eosio_system_tester {
 
    action_result updateauth(permission_level pl, name account, name permission, name parent, authority auth, name authorized_by) {
       return push_action_raw(
-         config::system_account_name, N(updateauth), pl, account, permission, parent, auth, authorized_by);
+         config::system_account_name, "updateauth"_n, pl, account, permission, parent, auth, authorized_by);
    }
 
    action_result deleteauth(permission_level pl, name account, name permission, name authorized_by) {
       return push_action_raw(
-         config::system_account_name, N(deleteauth), pl, account, permission, authorized_by);
+         config::system_account_name, "deleteauth"_n, pl, account, permission, authorized_by);
    }
 
    action_result linkauth(permission_level pl, name account, name code, name type, name requirement, name authorized_by) {
       return push_action_raw(
-         config::system_account_name, N(linkauth), pl, account, code, type, requirement, authorized_by);
+         config::system_account_name, "linkauth"_n, pl, account, code, type, requirement, authorized_by);
    }
 
    action_result unlinkauth(permission_level pl, name account, name code, name type, name authorized_by) {
       return push_action_raw(
-         config::system_account_name, N(unlinkauth), pl, account, code, type, authorized_by);
+         config::system_account_name, "unlinkauth"_n, pl, account, code, type, authorized_by);
    }
 }; // limitauth_tester
 
@@ -119,7 +119,7 @@ BOOST_FIXTURE_TEST_CASE(native_tests, limitauth_tester) try {
       updateauth({alice, active}, alice, freebie, active, get_public_key(alice, "freebie")));
    BOOST_REQUIRE_EQUAL(
       "",
-      linkauth({alice, active}, alice, N(eosio.null), N(noop), freebie));
+      linkauth({alice, active}, alice, "eosio.null"_n, "noop"_n, freebie));
 
    // alice@freebie can create alice@freebie2
    BOOST_REQUIRE_EQUAL(
@@ -129,12 +129,12 @@ BOOST_FIXTURE_TEST_CASE(native_tests, limitauth_tester) try {
    // alice@freebie can linkauth
    BOOST_REQUIRE_EQUAL(
       "",
-      linkauth({alice, freebie}, alice, N(eosio.null), N(noop), freebie2));
+      linkauth({alice, freebie}, alice, "eosio.null"_n, "noop"_n, freebie2));
 
    // alice@freebie can unlinkauth
    BOOST_REQUIRE_EQUAL(
       "",
-      unlinkauth({alice, freebie}, alice, N(eosio.null), N(noop)));
+      unlinkauth({alice, freebie}, alice, "eosio.null"_n, "noop"_n));
 
    // alice@freebie can delete alice@freebie2
    BOOST_REQUIRE_EQUAL(
@@ -152,35 +152,35 @@ FC_LOG_AND_RETHROW()
 BOOST_FIXTURE_TEST_CASE(extended_empty_tests, limitauth_tester) try {
    BOOST_REQUIRE_EQUAL(
       "",
-      updateauth({alice, active}, alice, freebie, active, get_public_key(alice, "freebie"), N()));
+      updateauth({alice, active}, alice, freebie, active, get_public_key(alice, "freebie"), ""_n));
    BOOST_REQUIRE_EQUAL(
       "",
-      linkauth({alice, active}, alice, N(eosio.null), N(noop), freebie, N()));
+      linkauth({alice, active}, alice, "eosio.null"_n, "noop"_n, freebie, ""_n));
 
    // alice@freebie can create alice@freebie2
    BOOST_REQUIRE_EQUAL(
       "",
-      updateauth({alice, freebie}, alice, freebie2, freebie, get_public_key(alice, "freebie2"), N()));
+      updateauth({alice, freebie}, alice, freebie2, freebie, get_public_key(alice, "freebie2"), ""_n));
 
    // alice@freebie can linkauth
    BOOST_REQUIRE_EQUAL(
       "",
-      linkauth({alice, freebie}, alice, N(eosio.null), N(noop), freebie2, N()));
+      linkauth({alice, freebie}, alice, "eosio.null"_n, "noop"_n, freebie2, ""_n));
 
    // alice@freebie can unlinkauth
    BOOST_REQUIRE_EQUAL(
       "",
-      unlinkauth({alice, freebie}, alice, N(eosio.null), N(noop), N()));
+      unlinkauth({alice, freebie}, alice, "eosio.null"_n, "noop"_n, ""_n));
 
    // alice@freebie can delete alice@freebie2
    BOOST_REQUIRE_EQUAL(
       "",
-      deleteauth({alice, freebie}, alice, freebie2, N()));
+      deleteauth({alice, freebie}, alice, freebie2, ""_n));
 
    // bob, who has the published freebie key, attacks
    BOOST_REQUIRE_EQUAL(
       "",
-      updateauth({alice, freebie}, alice, freebie, active, get_public_key(bob, "attack"), N()));
+      updateauth({alice, freebie}, alice, freebie, active, get_public_key(bob, "attack"), ""_n));
 } // extended_empty_tests
 FC_LOG_AND_RETHROW()
 
@@ -195,10 +195,10 @@ BOOST_FIXTURE_TEST_CASE(extended_matching_tests, limitauth_tester) try {
 
    BOOST_REQUIRE_EQUAL(
       "missing authority of alice1111111/owner",
-      linkauth({alice, active}, alice, N(eosio.null), N(noop), freebie, owner));
+      linkauth({alice, active}, alice, "eosio.null"_n, "noop"_n, freebie, owner));
    BOOST_REQUIRE_EQUAL(
       "",
-      linkauth({alice, active}, alice, N(eosio.null), N(noop), freebie, active));
+      linkauth({alice, active}, alice, "eosio.null"_n, "noop"_n, freebie, active));
 
    // alice@freebie can create alice@freebie2
    BOOST_REQUIRE_EQUAL(
@@ -208,15 +208,15 @@ BOOST_FIXTURE_TEST_CASE(extended_matching_tests, limitauth_tester) try {
    // alice@freebie can linkauth
    BOOST_REQUIRE_EQUAL(
       "",
-      linkauth({alice, freebie}, alice, N(eosio.null), N(noop), freebie2, freebie));
+      linkauth({alice, freebie}, alice, "eosio.null"_n, "noop"_n, freebie2, freebie));
 
    // alice@freebie can unlinkauth
    BOOST_REQUIRE_EQUAL(
       "missing authority of alice1111111/active",
-      unlinkauth({alice, freebie}, alice, N(eosio.null), N(noop), active));
+      unlinkauth({alice, freebie}, alice, "eosio.null"_n, "noop"_n, active));
    BOOST_REQUIRE_EQUAL(
       "",
-      unlinkauth({alice, freebie}, alice, N(eosio.null), N(noop), freebie));
+      unlinkauth({alice, freebie}, alice, "eosio.null"_n, "noop"_n, freebie));
 
    // alice@freebie can delete alice@freebie2
    BOOST_REQUIRE_EQUAL(
@@ -253,10 +253,10 @@ BOOST_FIXTURE_TEST_CASE(allow_perms_tests, limitauth_tester) try {
       updateauth({alice, active}, alice, admin, active, get_public_key(alice, "admin"), active));
    BOOST_REQUIRE_EQUAL(
       "",
-      linkauth({alice, active}, alice, N(eosio.null), N(noop), freebie, active));
+      linkauth({alice, active}, alice, "eosio.null"_n, "noop"_n, freebie, active));
    BOOST_REQUIRE_EQUAL(
       "",
-      linkauth({alice, active}, alice, N(eosio.null), N(dosomething), admin, active));
+      linkauth({alice, active}, alice, "eosio.null"_n, "dosomething"_n, admin, active));
 
    // Bob, who has the published freebie key, tries using updateauth to modify alice@freebie
    BOOST_REQUIRE_EQUAL(
@@ -264,7 +264,7 @@ BOOST_FIXTURE_TEST_CASE(allow_perms_tests, limitauth_tester) try {
       updateauth({alice, freebie}, alice, freebie, active, get_public_key(bob, "attack")));
    BOOST_REQUIRE_EQUAL(
       "assertion failure with message: authorized_by is required for this account",
-      updateauth({alice, freebie}, alice, freebie, active, get_public_key(bob, "attack"), N()));
+      updateauth({alice, freebie}, alice, freebie, active, get_public_key(bob, "attack"), ""_n));
    BOOST_REQUIRE_EQUAL(
       "assertion failure with message: authorized_by does not appear in allow_perms",
       updateauth({alice, freebie}, alice, freebie, active, get_public_key(bob, "attack"), freebie));
@@ -285,16 +285,16 @@ BOOST_FIXTURE_TEST_CASE(allow_perms_tests, limitauth_tester) try {
    // Bob, who has the published freebie key, tries using linkauth
    BOOST_REQUIRE_EQUAL(
       "assertion failure with message: authorized_by is required for this account",
-      linkauth({alice, freebie}, alice, N(eosio.null), N(noop), freebie2));
+      linkauth({alice, freebie}, alice, "eosio.null"_n, "noop"_n, freebie2));
    BOOST_REQUIRE_EQUAL(
       "assertion failure with message: authorized_by is required for this account",
-      linkauth({alice, freebie}, alice, N(eosio.null), N(noop), freebie2, N()));
+      linkauth({alice, freebie}, alice, "eosio.null"_n, "noop"_n, freebie2, ""_n));
    BOOST_REQUIRE_EQUAL(
       "assertion failure with message: authorized_by does not appear in allow_perms",
-      linkauth({alice, freebie}, alice, N(eosio.null), N(noop), freebie2, freebie));
+      linkauth({alice, freebie}, alice, "eosio.null"_n, "noop"_n, freebie2, freebie));
    BOOST_REQUIRE_EQUAL(
       "missing authority of alice1111111/active",
-      linkauth({alice, freebie}, alice, N(eosio.null), N(noop), freebie2, active));
+      linkauth({alice, freebie}, alice, "eosio.null"_n, "noop"_n, freebie2, active));
 
    // Bob, who has the published freebie key, tries using deleteauth
    BOOST_REQUIRE_EQUAL(
@@ -302,7 +302,7 @@ BOOST_FIXTURE_TEST_CASE(allow_perms_tests, limitauth_tester) try {
       deleteauth({alice, freebie}, alice, freebie2));
    BOOST_REQUIRE_EQUAL(
       "assertion failure with message: authorized_by is required for this account",
-      deleteauth({alice, freebie}, alice, freebie2, N()));
+      deleteauth({alice, freebie}, alice, freebie2, ""_n));
    BOOST_REQUIRE_EQUAL(
       "assertion failure with message: authorized_by does not appear in allow_perms",
       deleteauth({alice, freebie}, alice, freebie2, freebie));
@@ -313,16 +313,16 @@ BOOST_FIXTURE_TEST_CASE(allow_perms_tests, limitauth_tester) try {
    // Bob, who has the published freebie key, tries using unlinkauth
    BOOST_REQUIRE_EQUAL(
       "assertion failure with message: authorized_by is required for this account",
-      unlinkauth({alice, freebie}, alice, N(eosio.null), N(noop)));
+      unlinkauth({alice, freebie}, alice, "eosio.null"_n, "noop"_n));
    BOOST_REQUIRE_EQUAL(
       "assertion failure with message: authorized_by is required for this account",
-      unlinkauth({alice, freebie}, alice, N(eosio.null), N(noop), N()));
+      unlinkauth({alice, freebie}, alice, "eosio.null"_n, "noop"_n, ""_n));
    BOOST_REQUIRE_EQUAL(
       "assertion failure with message: authorized_by does not appear in allow_perms",
-      unlinkauth({alice, freebie}, alice, N(eosio.null), N(noop), freebie));
+      unlinkauth({alice, freebie}, alice, "eosio.null"_n, "noop"_n, freebie));
    BOOST_REQUIRE_EQUAL(
       "missing authority of alice1111111/active",
-      unlinkauth({alice, freebie}, alice, N(eosio.null), N(noop), active));
+      unlinkauth({alice, freebie}, alice, "eosio.null"_n, "noop"_n, active));
 
    // alice@admin can do these
    BOOST_REQUIRE_EQUAL(
@@ -330,10 +330,10 @@ BOOST_FIXTURE_TEST_CASE(allow_perms_tests, limitauth_tester) try {
       updateauth({alice, admin}, alice, admin2, admin, get_public_key(alice, "admin2"), admin));
    BOOST_REQUIRE_EQUAL(
       "",
-      linkauth({alice, admin}, alice, N(eosio.null), N(dosomething), admin2, admin));
+      linkauth({alice, admin}, alice, "eosio.null"_n, "dosomething"_n, admin2, admin));
    BOOST_REQUIRE_EQUAL(
       "",
-      unlinkauth({alice, admin}, alice, N(eosio.null), N(dosomething), admin));
+      unlinkauth({alice, admin}, alice, "eosio.null"_n, "dosomething"_n, admin));
    BOOST_REQUIRE_EQUAL(
       "",
       deleteauth({alice, admin}, alice, admin2, admin));
@@ -344,10 +344,10 @@ BOOST_FIXTURE_TEST_CASE(allow_perms_tests, limitauth_tester) try {
       updateauth({alice, active}, alice, admin2, admin, get_public_key(alice, "admin2"), active));
    BOOST_REQUIRE_EQUAL(
       "",
-      linkauth({alice, active}, alice, N(eosio.null), N(dosomething), admin2, active));
+      linkauth({alice, active}, alice, "eosio.null"_n, "dosomething"_n, admin2, active));
    BOOST_REQUIRE_EQUAL(
       "",
-      unlinkauth({alice, active}, alice, N(eosio.null), N(dosomething), active));
+      unlinkauth({alice, active}, alice, "eosio.null"_n, "dosomething"_n, active));
    BOOST_REQUIRE_EQUAL(
       "",
       deleteauth({alice, active}, alice, admin2, active));
@@ -358,10 +358,10 @@ BOOST_FIXTURE_TEST_CASE(allow_perms_tests, limitauth_tester) try {
       updateauth({alice, owner}, alice, admin2, admin, get_public_key(alice, "admin2"), owner));
    BOOST_REQUIRE_EQUAL(
       "",
-      linkauth({alice, owner}, alice, N(eosio.null), N(dosomething), admin2, owner));
+      linkauth({alice, owner}, alice, "eosio.null"_n, "dosomething"_n, admin2, owner));
    BOOST_REQUIRE_EQUAL(
       "",
-      unlinkauth({alice, owner}, alice, N(eosio.null), N(dosomething), owner));
+      unlinkauth({alice, owner}, alice, "eosio.null"_n, "dosomething"_n, owner));
    BOOST_REQUIRE_EQUAL(
       "",
       deleteauth({alice, owner}, alice, admin2, owner));
@@ -388,10 +388,10 @@ BOOST_FIXTURE_TEST_CASE(disallow_perms_tests, limitauth_tester) try {
       updateauth({alice, active}, alice, admin, active, get_public_key(alice, "admin"), active));
    BOOST_REQUIRE_EQUAL(
       "",
-      linkauth({alice, active}, alice, N(eosio.null), N(noop), freebie, active));
+      linkauth({alice, active}, alice, "eosio.null"_n, "noop"_n, freebie, active));
    BOOST_REQUIRE_EQUAL(
       "",
-      linkauth({alice, active}, alice, N(eosio.null), N(dosomething), admin, active));
+      linkauth({alice, active}, alice, "eosio.null"_n, "dosomething"_n, admin, active));
 
    // Bob, who has the published freebie key, tries using updateauth to modify alice@freebie
    BOOST_REQUIRE_EQUAL(
@@ -399,7 +399,7 @@ BOOST_FIXTURE_TEST_CASE(disallow_perms_tests, limitauth_tester) try {
       updateauth({alice, freebie}, alice, freebie, active, get_public_key(bob, "attack")));
    BOOST_REQUIRE_EQUAL(
       "assertion failure with message: authorized_by is required for this account",
-      updateauth({alice, freebie}, alice, freebie, active, get_public_key(bob, "attack"), N()));
+      updateauth({alice, freebie}, alice, freebie, active, get_public_key(bob, "attack"), ""_n));
    BOOST_REQUIRE_EQUAL(
       "assertion failure with message: authorized_by appears in disallow_perms",
       updateauth({alice, freebie}, alice, freebie, active, get_public_key(bob, "attack"), freebie));
@@ -420,16 +420,16 @@ BOOST_FIXTURE_TEST_CASE(disallow_perms_tests, limitauth_tester) try {
    // Bob, who has the published freebie key, tries using linkauth
    BOOST_REQUIRE_EQUAL(
       "assertion failure with message: authorized_by is required for this account",
-      linkauth({alice, freebie}, alice, N(eosio.null), N(noop), freebie2));
+      linkauth({alice, freebie}, alice, "eosio.null"_n, "noop"_n, freebie2));
    BOOST_REQUIRE_EQUAL(
       "assertion failure with message: authorized_by is required for this account",
-      linkauth({alice, freebie}, alice, N(eosio.null), N(noop), freebie2, N()));
+      linkauth({alice, freebie}, alice, "eosio.null"_n, "noop"_n, freebie2, ""_n));
    BOOST_REQUIRE_EQUAL(
       "assertion failure with message: authorized_by appears in disallow_perms",
-      linkauth({alice, freebie}, alice, N(eosio.null), N(noop), freebie2, freebie));
+      linkauth({alice, freebie}, alice, "eosio.null"_n, "noop"_n, freebie2, freebie));
    BOOST_REQUIRE_EQUAL(
       "missing authority of alice1111111/active",
-      linkauth({alice, freebie}, alice, N(eosio.null), N(noop), freebie2, active));
+      linkauth({alice, freebie}, alice, "eosio.null"_n, "noop"_n, freebie2, active));
 
    // Bob, who has the published freebie key, tries using deleteauth
    BOOST_REQUIRE_EQUAL(
@@ -437,7 +437,7 @@ BOOST_FIXTURE_TEST_CASE(disallow_perms_tests, limitauth_tester) try {
       deleteauth({alice, freebie}, alice, freebie2));
    BOOST_REQUIRE_EQUAL(
       "assertion failure with message: authorized_by is required for this account",
-      deleteauth({alice, freebie}, alice, freebie2, N()));
+      deleteauth({alice, freebie}, alice, freebie2, ""_n));
    BOOST_REQUIRE_EQUAL(
       "assertion failure with message: authorized_by appears in disallow_perms",
       deleteauth({alice, freebie}, alice, freebie2, freebie));
@@ -448,16 +448,16 @@ BOOST_FIXTURE_TEST_CASE(disallow_perms_tests, limitauth_tester) try {
    // Bob, who has the published freebie key, tries using unlinkauth
    BOOST_REQUIRE_EQUAL(
       "assertion failure with message: authorized_by is required for this account",
-      unlinkauth({alice, freebie}, alice, N(eosio.null), N(noop)));
+      unlinkauth({alice, freebie}, alice, "eosio.null"_n, "noop"_n));
    BOOST_REQUIRE_EQUAL(
       "assertion failure with message: authorized_by is required for this account",
-      unlinkauth({alice, freebie}, alice, N(eosio.null), N(noop), N()));
+      unlinkauth({alice, freebie}, alice, "eosio.null"_n, "noop"_n, ""_n));
    BOOST_REQUIRE_EQUAL(
       "assertion failure with message: authorized_by appears in disallow_perms",
-      unlinkauth({alice, freebie}, alice, N(eosio.null), N(noop), freebie));
+      unlinkauth({alice, freebie}, alice, "eosio.null"_n, "noop"_n, freebie));
    BOOST_REQUIRE_EQUAL(
       "missing authority of alice1111111/active",
-      unlinkauth({alice, freebie}, alice, N(eosio.null), N(noop), active));
+      unlinkauth({alice, freebie}, alice, "eosio.null"_n, "noop"_n, active));
 
    // alice@admin can do these
    BOOST_REQUIRE_EQUAL(
@@ -465,10 +465,10 @@ BOOST_FIXTURE_TEST_CASE(disallow_perms_tests, limitauth_tester) try {
       updateauth({alice, admin}, alice, admin2, admin, get_public_key(alice, "admin2"), admin));
    BOOST_REQUIRE_EQUAL(
       "",
-      linkauth({alice, admin}, alice, N(eosio.null), N(dosomething), admin2, admin));
+      linkauth({alice, admin}, alice, "eosio.null"_n, "dosomething"_n, admin2, admin));
    BOOST_REQUIRE_EQUAL(
       "",
-      unlinkauth({alice, admin}, alice, N(eosio.null), N(dosomething), admin));
+      unlinkauth({alice, admin}, alice, "eosio.null"_n, "dosomething"_n, admin));
    BOOST_REQUIRE_EQUAL(
       "",
       deleteauth({alice, admin}, alice, admin2, admin));
@@ -479,10 +479,10 @@ BOOST_FIXTURE_TEST_CASE(disallow_perms_tests, limitauth_tester) try {
       updateauth({alice, active}, alice, admin2, admin, get_public_key(alice, "admin2"), active));
    BOOST_REQUIRE_EQUAL(
       "",
-      linkauth({alice, active}, alice, N(eosio.null), N(dosomething), admin2, active));
+      linkauth({alice, active}, alice, "eosio.null"_n, "dosomething"_n, admin2, active));
    BOOST_REQUIRE_EQUAL(
       "",
-      unlinkauth({alice, active}, alice, N(eosio.null), N(dosomething), active));
+      unlinkauth({alice, active}, alice, "eosio.null"_n, "dosomething"_n, active));
    BOOST_REQUIRE_EQUAL(
       "",
       deleteauth({alice, active}, alice, admin2, active));
@@ -493,10 +493,10 @@ BOOST_FIXTURE_TEST_CASE(disallow_perms_tests, limitauth_tester) try {
       updateauth({alice, owner}, alice, admin2, admin, get_public_key(alice, "admin2"), owner));
    BOOST_REQUIRE_EQUAL(
       "",
-      linkauth({alice, owner}, alice, N(eosio.null), N(dosomething), admin2, owner));
+      linkauth({alice, owner}, alice, "eosio.null"_n, "dosomething"_n, admin2, owner));
    BOOST_REQUIRE_EQUAL(
       "",
-      unlinkauth({alice, owner}, alice, N(eosio.null), N(dosomething), owner));
+      unlinkauth({alice, owner}, alice, "eosio.null"_n, "dosomething"_n, owner));
    BOOST_REQUIRE_EQUAL(
       "",
       deleteauth({alice, owner}, alice, admin2, owner));

--- a/tests/eosio.msig_tests.cpp
+++ b/tests/eosio.msig_tests.cpp
@@ -20,20 +20,20 @@ using mvo = fc::mutable_variant_object;
 class eosio_msig_tester : public tester {
 public:
    eosio_msig_tester() {
-      create_accounts( { N(eosio.msig), N(eosio.stake), N(eosio.ram), N(eosio.ramfee), N(alice), N(bob), N(carol) } );
+      create_accounts( { "eosio.msig"_n, "eosio.stake"_n, "eosio.ram"_n, "eosio.ramfee"_n, "alice"_n, "bob"_n, "carol"_n } );
       produce_block();
 
-      auto trace = base_tester::push_action(config::system_account_name, N(setpriv),
+      auto trace = base_tester::push_action(config::system_account_name, "setpriv"_n,
                                             config::system_account_name,  mutable_variant_object()
                                             ("account", "eosio.msig")
                                             ("is_priv", 1)
       );
 
-      set_code( N(eosio.msig), contracts::msig_wasm() );
-      set_abi( N(eosio.msig), contracts::msig_abi().data() );
+      set_code( "eosio.msig"_n, contracts::msig_wasm() );
+      set_abi( "eosio.msig"_n, contracts::msig_abi().data() );
 
       produce_blocks();
-      const auto& accnt = control->db().get<account_object,by_name>( N(eosio.msig) );
+      const auto& accnt = control->db().get<account_object,by_name>( "eosio.msig"_n );
       abi_def abi;
       BOOST_REQUIRE_EQUAL(abi_serializer::to_abi(accnt.abi, abi), true);
       abi_ser.set_abi(abi, abi_serializer::create_yield_function(abi_serializer_max_time));
@@ -60,14 +60,14 @@ public:
                                    .active   = authority( get_public_key( a, "active" ) )
                                 });
 
-      trx.actions.emplace_back( get_action( N(eosio), N(buyram), vector<permission_level>{{creator,config::active_name}},
+      trx.actions.emplace_back( get_action( "eosio"_n, "buyram"_n, vector<permission_level>{{creator,config::active_name}},
                                             mvo()
                                             ("payer", creator)
                                             ("receiver", a)
                                             ("quant", ramfunds) )
                               );
 
-      trx.actions.emplace_back( get_action( N(eosio), N(delegatebw), vector<permission_level>{{creator,config::active_name}},
+      trx.actions.emplace_back( get_action( "eosio"_n, "delegatebw"_n, vector<permission_level>{{creator,config::active_name}},
                                             mvo()
                                             ("from", creator)
                                             ("receiver", a)
@@ -86,17 +86,17 @@ public:
          ("issuer",       manager )
          ("maximum_supply", maxsupply );
 
-      base_tester::push_action(contract, N(create), contract, act );
+      base_tester::push_action(contract, "create"_n, contract, act );
    }
    void issue( name to, const asset& amount, name manager = config::system_account_name ) {
-      base_tester::push_action( N(eosio.token), N(issue), manager, mutable_variant_object()
+      base_tester::push_action( "eosio.token"_n, "issue"_n, manager, mutable_variant_object()
                                 ("to",      to )
                                 ("quantity", amount )
                                 ("memo", "")
                                 );
    }
    void transfer( name from, name to, const string& amount, name manager = config::system_account_name ) {
-      base_tester::push_action( N(eosio.token), N(transfer), manager, mutable_variant_object()
+      base_tester::push_action( "eosio.token"_n, "transfer"_n, manager, mutable_variant_object()
                                 ("from",    from)
                                 ("to",      to )
                                 ("quantity", asset::from_string(amount) )
@@ -105,10 +105,10 @@ public:
    }
    asset get_balance( const account_name& act ) {
       //return get_currency_balance( config::system_account_name, symbol(CORE_SYMBOL), act );
-      //temporary code. current get_currency_balancy uses table name N(accounts) from currency.h
-      //generic_currency table name is N(account).
+      //temporary code. current get_currency_balancy uses table name "accounts"_n from currency.h
+      //generic_currency table name is "account"_n.
       const auto& db  = control->db();
-      const auto* tbl = db.find<table_id_object, by_code_scope_table>(boost::make_tuple(N(eosio.token), act, N(accounts)));
+      const auto* tbl = db.find<table_id_object, by_code_scope_table>(boost::make_tuple("eosio.token"_n, act, "accounts"_n));
       share_type result = 0;
 
       // the balance is implied to be 0 if either the table or row does not exist
@@ -127,7 +127,7 @@ public:
       vector<account_name> accounts;
       if( auth )
          accounts.push_back( signer );
-      auto trace = base_tester::push_action( N(eosio.msig), name, accounts, data );
+      auto trace = base_tester::push_action( "eosio.msig"_n, name, accounts, data );
       produce_block();
       BOOST_REQUIRE_EQUAL( true, chain_has_transaction(trace->id) );
       return trace;
@@ -136,7 +136,7 @@ public:
          string action_type_name = abi_ser.get_action_type(name);
 
          action act;
-         act.account = N(eosio.msig);
+         act.account = "eosio.msig"_n;
          act.name = name;
          act.data = abi_ser.variant_to_binary( action_type_name, data, abi_serializer::create_yield_function(abi_serializer_max_time) );
          //std::cout << "test:\n" << fc::to_hex(act.data.data(), act.data.size()) << " size = " << act.data.size() << std::endl;
@@ -158,7 +158,7 @@ transaction eosio_msig_tester::reqauth( account_name from, const vector<permissi
                   ("permission", level.permission)
       );
    }
-   variant pretty_trx = fc::mutable_variant_object()
+   fc::variant pretty_trx = fc::mutable_variant_object()
       ("expiration", "2020-01-01T00:30")
       ("ref_block_num", 2)
       ("ref_block_prefix", 3)
@@ -181,17 +181,17 @@ transaction eosio_msig_tester::reqauth( account_name from, const vector<permissi
 BOOST_AUTO_TEST_SUITE(eosio_msig_tests)
 
 BOOST_FIXTURE_TEST_CASE( propose_approve_execute, eosio_msig_tester ) try {
-   auto trx = reqauth( N(alice), {permission_level{N(alice), config::active_name}}, abi_serializer_max_time );
+   auto trx = reqauth( "alice"_n, {permission_level{"alice"_n, config::active_name}}, abi_serializer_max_time );
 
-   push_action( N(alice), N(propose), mvo()
+   push_action( "alice"_n, "propose"_n, mvo()
                   ("proposer",      "alice")
                   ("proposal_name", "first")
                   ("trx",           trx)
-                  ("requested", vector<permission_level>{{ N(alice), config::active_name }})
+                  ("requested", vector<permission_level>{{ "alice"_n, config::active_name }})
    );
 
    //fail to execute before approval
-   BOOST_REQUIRE_EXCEPTION( push_action( N(alice), N(exec), mvo()
+   BOOST_REQUIRE_EXCEPTION( push_action( "alice"_n, "exec"_n, mvo()
                                           ("proposer",      "alice")
                                           ("proposal_name", "first")
                                           ("executer",      "alice")
@@ -201,10 +201,10 @@ BOOST_FIXTURE_TEST_CASE( propose_approve_execute, eosio_msig_tester ) try {
    );
 
    //approve and execute
-   push_action( N(alice), N(approve), mvo()
+   push_action( "alice"_n, "approve"_n, mvo()
                   ("proposer",      "alice")
                   ("proposal_name", "first")
-                  ("level",         permission_level{ N(alice), config::active_name })
+                  ("level",         permission_level{ "alice"_n, config::active_name })
    );
 
    transaction_trace_ptr trace;
@@ -213,7 +213,7 @@ BOOST_FIXTURE_TEST_CASE( propose_approve_execute, eosio_msig_tester ) try {
       const auto& t = std::get<0>(p);
       if( t->scheduled ) { trace = t; }
    } );
-   push_action( N(alice), N(exec), mvo()
+   push_action( "alice"_n, "exec"_n, mvo()
                   ("proposer",      "alice")
                   ("proposal_name", "first")
                   ("executer",      "alice")
@@ -226,28 +226,28 @@ BOOST_FIXTURE_TEST_CASE( propose_approve_execute, eosio_msig_tester ) try {
 
 
 BOOST_FIXTURE_TEST_CASE( propose_approve_unapprove, eosio_msig_tester ) try {
-   auto trx = reqauth( N(alice), {permission_level{N(alice), config::active_name}}, abi_serializer_max_time );
+   auto trx = reqauth( "alice"_n, {permission_level{"alice"_n, config::active_name}}, abi_serializer_max_time );
 
-   push_action( N(alice), N(propose), mvo()
+   push_action( "alice"_n, "propose"_n, mvo()
                   ("proposer",      "alice")
                   ("proposal_name", "first")
                   ("trx",           trx)
-                  ("requested", vector<permission_level>{{ N(alice), config::active_name }})
+                  ("requested", vector<permission_level>{{ "alice"_n, config::active_name }})
    );
 
-   push_action( N(alice), N(approve), mvo()
+   push_action( "alice"_n, "approve"_n, mvo()
                   ("proposer",      "alice")
                   ("proposal_name", "first")
-                  ("level",         permission_level{ N(alice), config::active_name })
+                  ("level",         permission_level{ "alice"_n, config::active_name })
    );
 
-   push_action( N(alice), N(unapprove), mvo()
+   push_action( "alice"_n, "unapprove"_n, mvo()
                   ("proposer",      "alice")
                   ("proposal_name", "first")
-                  ("level",         permission_level{ N(alice), config::active_name })
+                  ("level",         permission_level{ "alice"_n, config::active_name })
    );
 
-   BOOST_REQUIRE_EXCEPTION( push_action( N(alice), N(exec), mvo()
+   BOOST_REQUIRE_EXCEPTION( push_action( "alice"_n, "exec"_n, mvo()
                                           ("proposer",      "alice")
                                           ("proposal_name", "first")
                                           ("executer",      "alice")
@@ -260,24 +260,24 @@ BOOST_FIXTURE_TEST_CASE( propose_approve_unapprove, eosio_msig_tester ) try {
 
 
 BOOST_FIXTURE_TEST_CASE( propose_approve_by_two, eosio_msig_tester ) try {
-   auto trx = reqauth( N(alice), vector<permission_level>{ { N(alice), config::active_name }, { N(bob), config::active_name } }, abi_serializer_max_time );
-   push_action( N(alice), N(propose), mvo()
+   auto trx = reqauth( "alice"_n, vector<permission_level>{ { "alice"_n, config::active_name }, { "bob"_n, config::active_name } }, abi_serializer_max_time );
+   push_action( "alice"_n, "propose"_n, mvo()
                   ("proposer",      "alice")
                   ("proposal_name", "first")
                   ("trx",           trx)
-                  ("requested", vector<permission_level>{ { N(alice), config::active_name }, { N(bob), config::active_name } })
+                  ("requested", vector<permission_level>{ { "alice"_n, config::active_name }, { "bob"_n, config::active_name } })
    );
 
    //approve by alice
-   push_action( N(alice), N(approve), mvo()
+   push_action( "alice"_n, "approve"_n, mvo()
                   ("proposer",      "alice")
                   ("proposal_name", "first")
-                  ("level",         permission_level{ N(alice), config::active_name })
+                  ("level",         permission_level{ "alice"_n, config::active_name })
    );
 
    //fail because approval by bob is missing
 
-   BOOST_REQUIRE_EXCEPTION( push_action( N(alice), N(exec), mvo()
+   BOOST_REQUIRE_EXCEPTION( push_action( "alice"_n, "exec"_n, mvo()
                                           ("proposer",      "alice")
                                           ("proposal_name", "first")
                                           ("executer",      "alice")
@@ -287,10 +287,10 @@ BOOST_FIXTURE_TEST_CASE( propose_approve_by_two, eosio_msig_tester ) try {
    );
 
    //approve by bob and execute
-   push_action( N(bob), N(approve), mvo()
+   push_action( "bob"_n, "approve"_n, mvo()
                   ("proposer",      "alice")
                   ("proposal_name", "first")
-                  ("level",         permission_level{ N(bob), config::active_name })
+                  ("level",         permission_level{ "bob"_n, config::active_name })
    );
 
    transaction_trace_ptr trace;
@@ -300,7 +300,7 @@ BOOST_FIXTURE_TEST_CASE( propose_approve_by_two, eosio_msig_tester ) try {
       if( t->scheduled ) { trace = t; }
    } );
 
-   push_action( N(alice), N(exec), mvo()
+   push_action( "alice"_n, "exec"_n, mvo()
                   ("proposer",      "alice")
                   ("proposal_name", "first")
                   ("executer",      "alice")
@@ -313,13 +313,13 @@ BOOST_FIXTURE_TEST_CASE( propose_approve_by_two, eosio_msig_tester ) try {
 
 
 BOOST_FIXTURE_TEST_CASE( propose_with_wrong_requested_auth, eosio_msig_tester ) try {
-   auto trx = reqauth( N(alice), vector<permission_level>{ { N(alice), config::active_name },  { N(bob), config::active_name } }, abi_serializer_max_time );
+   auto trx = reqauth( "alice"_n, vector<permission_level>{ { "alice"_n, config::active_name },  { "bob"_n, config::active_name } }, abi_serializer_max_time );
    //try with not enough requested auth
-   BOOST_REQUIRE_EXCEPTION( push_action( N(alice), N(propose), mvo()
+   BOOST_REQUIRE_EXCEPTION( push_action( "alice"_n, "propose"_n, mvo()
                                              ("proposer",      "alice")
                                              ("proposal_name", "third")
                                              ("trx",           trx)
-                                             ("requested", vector<permission_level>{ { N(alice), config::active_name } } )
+                                             ("requested", vector<permission_level>{ { "alice"_n, config::active_name } } )
                             ),
                             eosio_assert_message_exception,
                             eosio_assert_message_is("transaction authorization failed")
@@ -329,10 +329,10 @@ BOOST_FIXTURE_TEST_CASE( propose_with_wrong_requested_auth, eosio_msig_tester ) 
 
 
 BOOST_FIXTURE_TEST_CASE( big_transaction, eosio_msig_tester ) try {
-   vector<permission_level> perm = { { N(alice), config::active_name }, { N(bob), config::active_name } };
+   vector<permission_level> perm = { { "alice"_n, config::active_name }, { "bob"_n, config::active_name } };
    auto wasm = contracts::util::exchange_wasm();
 
-   variant pretty_trx = fc::mutable_variant_object()
+   fc::variant pretty_trx = fc::mutable_variant_object()
       ("expiration", "2020-01-01T00:30")
       ("ref_block_num", 2)
       ("ref_block_prefix", 3)
@@ -356,7 +356,7 @@ BOOST_FIXTURE_TEST_CASE( big_transaction, eosio_msig_tester ) try {
    transaction trx;
    abi_serializer::from_variant(pretty_trx, trx, get_resolver(), abi_serializer::create_yield_function(abi_serializer_max_time));
 
-   push_action( N(alice), N(propose), mvo()
+   push_action( "alice"_n, "propose"_n, mvo()
                   ("proposer",      "alice")
                   ("proposal_name", "first")
                   ("trx",           trx)
@@ -364,16 +364,16 @@ BOOST_FIXTURE_TEST_CASE( big_transaction, eosio_msig_tester ) try {
    );
 
    //approve by alice
-   push_action( N(alice), N(approve), mvo()
+   push_action( "alice"_n, "approve"_n, mvo()
                   ("proposer",      "alice")
                   ("proposal_name", "first")
-                  ("level",         permission_level{ N(alice), config::active_name })
+                  ("level",         permission_level{ "alice"_n, config::active_name })
    );
    //approve by bob and execute
-   push_action( N(bob), N(approve), mvo()
+   push_action( "bob"_n, "approve"_n, mvo()
                   ("proposer",      "alice")
                   ("proposal_name", "first")
-                  ("level",         permission_level{ N(bob), config::active_name })
+                  ("level",         permission_level{ "bob"_n, config::active_name })
    );
 
    transaction_trace_ptr trace;
@@ -383,7 +383,7 @@ BOOST_FIXTURE_TEST_CASE( big_transaction, eosio_msig_tester ) try {
       if( t->scheduled ) { trace = t; }
    } );
 
-   push_action( N(alice), N(exec), mvo()
+   push_action( "alice"_n, "exec"_n, mvo()
                   ("proposer",      "alice")
                   ("proposal_name", "first")
                   ("executer",      "alice")
@@ -411,48 +411,48 @@ BOOST_FIXTURE_TEST_CASE( update_system_contract_all_approve, eosio_msig_tester )
       config::active_name,
       authority( 1,
                  vector<key_weight>{{get_private_key(config::system_account_name, "active").get_public_key(), 1}},
-                 vector<permission_level_weight>{{{N(eosio.prods), config::active_name}, 1}}
+                 vector<permission_level_weight>{{{"eosio.prods"_n, config::active_name}, 1}}
       ),
       config::owner_name,
       {{config::system_account_name, config::active_name}},
       {get_private_key(config::system_account_name, "active")}
    );
 
-   set_producers( {N(alice),N(bob),N(carol)} );
+   set_producers( {"alice"_n,"bob"_n,"carol"_n} );
    produce_blocks(50);
 
-   create_accounts( { N(eosio.token), N(eosio.rex) } );
-   set_code( N(eosio.token), contracts::token_wasm() );
-   set_abi( N(eosio.token), contracts::token_abi().data() );
+   create_accounts( { "eosio.token"_n, "eosio.rex"_n } );
+   set_code( "eosio.token"_n, contracts::token_wasm() );
+   set_abi( "eosio.token"_n, contracts::token_abi().data() );
 
-   create_currency( N(eosio.token), config::system_account_name, core_sym::from_string("10000000000.0000") );
+   create_currency( "eosio.token"_n, config::system_account_name, core_sym::from_string("10000000000.0000") );
    issue(config::system_account_name, core_sym::from_string("1000000000.0000"));
    BOOST_REQUIRE_EQUAL( core_sym::from_string("1000000000.0000"),
-                        get_balance(config::system_account_name) + get_balance(N(eosio.ramfee)) + get_balance(N(eosio.stake)) + get_balance(N(eosio.ram)) );
+                        get_balance(config::system_account_name) + get_balance("eosio.ramfee"_n) + get_balance("eosio.stake"_n) + get_balance("eosio.ram"_n) );
 
    set_code( config::system_account_name, contracts::system_wasm() );
    set_abi( config::system_account_name, contracts::system_abi().data() );
-   base_tester::push_action( config::system_account_name, N(init),
+   base_tester::push_action( config::system_account_name, "init"_n,
                              config::system_account_name,  mutable_variant_object()
                               ("version", 0)
                               ("core", CORE_SYM_STR)
    );
    produce_blocks();
-   create_account_with_resources( N(alice1111111), N(eosio), core_sym::from_string("1.0000"), false );
-   create_account_with_resources( N(bob111111111), N(eosio), core_sym::from_string("0.4500"), false );
-   create_account_with_resources( N(carol1111111), N(eosio), core_sym::from_string("1.0000"), false );
+   create_account_with_resources( "alice1111111"_n, "eosio"_n, core_sym::from_string("1.0000"), false );
+   create_account_with_resources( "bob111111111"_n, "eosio"_n, core_sym::from_string("0.4500"), false );
+   create_account_with_resources( "carol1111111"_n, "eosio"_n, core_sym::from_string("1.0000"), false );
 
    BOOST_REQUIRE_EQUAL( core_sym::from_string("1000000000.0000"),
-                        get_balance(config::system_account_name) + get_balance(N(eosio.ramfee)) + get_balance(N(eosio.stake)) + get_balance(N(eosio.ram)) );
+                        get_balance(config::system_account_name) + get_balance("eosio.ramfee"_n) + get_balance("eosio.stake"_n) + get_balance("eosio.ram"_n) );
 
-   vector<permission_level> perm = { { N(alice), config::active_name }, { N(bob), config::active_name },
-      {N(carol), config::active_name} };
+   vector<permission_level> perm = { { "alice"_n, config::active_name }, { "bob"_n, config::active_name },
+      {"carol"_n, config::active_name} };
 
-   vector<permission_level> action_perm = {{N(eosio), config::active_name}};
+   vector<permission_level> action_perm = {{"eosio"_n, config::active_name}};
 
    auto wasm = contracts::util::reject_all_wasm();
 
-   variant pretty_trx = fc::mutable_variant_object()
+   fc::variant pretty_trx = fc::mutable_variant_object()
       ("expiration", "2020-01-01T00:30")
       ("ref_block_num", 2)
       ("ref_block_prefix", 3)
@@ -477,7 +477,7 @@ BOOST_FIXTURE_TEST_CASE( update_system_contract_all_approve, eosio_msig_tester )
    abi_serializer::from_variant(pretty_trx, trx, get_resolver(), abi_serializer::create_yield_function(abi_serializer_max_time));
 
    // propose action
-   push_action( N(alice), N(propose), mvo()
+   push_action( "alice"_n, "propose"_n, mvo()
                   ("proposer",      "alice")
                   ("proposal_name", "first")
                   ("trx",           trx)
@@ -485,22 +485,22 @@ BOOST_FIXTURE_TEST_CASE( update_system_contract_all_approve, eosio_msig_tester )
    );
 
    //approve by alice
-   push_action( N(alice), N(approve), mvo()
+   push_action( "alice"_n, "approve"_n, mvo()
                   ("proposer",      "alice")
                   ("proposal_name", "first")
-                  ("level",         permission_level{ N(alice), config::active_name })
+                  ("level",         permission_level{ "alice"_n, config::active_name })
    );
    //approve by bob
-   push_action( N(bob), N(approve), mvo()
+   push_action( "bob"_n, "approve"_n, mvo()
                   ("proposer",      "alice")
                   ("proposal_name", "first")
-                  ("level",         permission_level{ N(bob), config::active_name })
+                  ("level",         permission_level{ "bob"_n, config::active_name })
    );
    //approve by carol
-   push_action( N(carol), N(approve), mvo()
+   push_action( "carol"_n, "approve"_n, mvo()
                   ("proposer",      "alice")
                   ("proposal_name", "first")
-                  ("level",         permission_level{ N(carol), config::active_name })
+                  ("level",         permission_level{ "carol"_n, config::active_name })
    );
    // execute by alice to replace the eosio system contract
    transaction_trace_ptr trace;
@@ -510,7 +510,7 @@ BOOST_FIXTURE_TEST_CASE( update_system_contract_all_approve, eosio_msig_tester )
       if( t->scheduled ) { trace = t; }
    } );
 
-   push_action( N(alice), N(exec), mvo()
+   push_action( "alice"_n, "exec"_n, mvo()
                   ("proposer",      "alice")
                   ("proposal_name", "first")
                   ("executer",      "alice")
@@ -522,7 +522,7 @@ BOOST_FIXTURE_TEST_CASE( update_system_contract_all_approve, eosio_msig_tester )
 
    // can't create account because system contract was replaced by the reject_all contract
 
-   BOOST_REQUIRE_EXCEPTION( create_account_with_resources( N(alice1111112), N(eosio), core_sym::from_string("1.0000"), false ),
+   BOOST_REQUIRE_EXCEPTION( create_account_with_resources( "alice1111112"_n, "eosio"_n, core_sym::from_string("1.0000"), false ),
                             eosio_assert_message_exception, eosio_assert_message_is("rejecting all actions")
 
    );
@@ -536,49 +536,49 @@ BOOST_FIXTURE_TEST_CASE( update_system_contract_major_approve, eosio_msig_tester
       config::active_name,
       authority( 1,
                  vector<key_weight>{{get_private_key(config::system_account_name, "active").get_public_key(), 1}},
-                 vector<permission_level_weight>{{{N(eosio.prods), config::active_name}, 1}}
+                 vector<permission_level_weight>{{{"eosio.prods"_n, config::active_name}, 1}}
       ),
       config::owner_name,
       {{config::system_account_name, config::active_name}},
       {get_private_key(config::system_account_name, "active")}
    );
 
-   create_accounts( { N(apple) } );
-   set_producers( {N(alice),N(bob),N(carol), N(apple)} );
+   create_accounts( { "apple"_n } );
+   set_producers( {"alice"_n,"bob"_n,"carol"_n, "apple"_n} );
    produce_blocks(50);
 
-   create_accounts( { N(eosio.token), N(eosio.rex) } );
-   set_code( N(eosio.token), contracts::token_wasm() );
-   set_abi( N(eosio.token), contracts::token_abi().data() );
+   create_accounts( { "eosio.token"_n, "eosio.rex"_n } );
+   set_code( "eosio.token"_n, contracts::token_wasm() );
+   set_abi( "eosio.token"_n, contracts::token_abi().data() );
 
-   create_currency( N(eosio.token), config::system_account_name, core_sym::from_string("10000000000.0000") );
+   create_currency( "eosio.token"_n, config::system_account_name, core_sym::from_string("10000000000.0000") );
    issue(config::system_account_name, core_sym::from_string("1000000000.0000"));
    BOOST_REQUIRE_EQUAL( core_sym::from_string("1000000000.0000"), get_balance( config::system_account_name ) );
 
    set_code( config::system_account_name, contracts::system_wasm() );
    set_abi( config::system_account_name, contracts::system_abi().data() );
-   base_tester::push_action( config::system_account_name, N(init),
+   base_tester::push_action( config::system_account_name, "init"_n,
                              config::system_account_name,  mutable_variant_object()
                                  ("version", 0)
                                  ("core", CORE_SYM_STR)
    );
    produce_blocks();
 
-   create_account_with_resources( N(alice1111111), N(eosio), core_sym::from_string("1.0000"), false );
-   create_account_with_resources( N(bob111111111), N(eosio), core_sym::from_string("0.4500"), false );
-   create_account_with_resources( N(carol1111111), N(eosio), core_sym::from_string("1.0000"), false );
+   create_account_with_resources( "alice1111111"_n, "eosio"_n, core_sym::from_string("1.0000"), false );
+   create_account_with_resources( "bob111111111"_n, "eosio"_n, core_sym::from_string("0.4500"), false );
+   create_account_with_resources( "carol1111111"_n, "eosio"_n, core_sym::from_string("1.0000"), false );
 
    BOOST_REQUIRE_EQUAL( core_sym::from_string("1000000000.0000"),
-                        get_balance(config::system_account_name) + get_balance(N(eosio.ramfee)) + get_balance(N(eosio.stake)) + get_balance(N(eosio.ram)) );
+                        get_balance(config::system_account_name) + get_balance("eosio.ramfee"_n) + get_balance("eosio.stake"_n) + get_balance("eosio.ram"_n) );
 
-   vector<permission_level> perm = { { N(alice), config::active_name }, { N(bob), config::active_name },
-      {N(carol), config::active_name}, {N(apple), config::active_name}};
+   vector<permission_level> perm = { { "alice"_n, config::active_name }, { "bob"_n, config::active_name },
+      {"carol"_n, config::active_name}, {"apple"_n, config::active_name}};
 
-   vector<permission_level> action_perm = {{N(eosio), config::active_name}};
+   vector<permission_level> action_perm = {{"eosio"_n, config::active_name}};
 
    auto wasm = contracts::util::reject_all_wasm();
 
-   variant pretty_trx = fc::mutable_variant_object()
+   fc::variant pretty_trx = fc::mutable_variant_object()
       ("expiration", "2020-01-01T00:30")
       ("ref_block_num", 2)
       ("ref_block_prefix", 3)
@@ -603,7 +603,7 @@ BOOST_FIXTURE_TEST_CASE( update_system_contract_major_approve, eosio_msig_tester
    abi_serializer::from_variant(pretty_trx, trx, get_resolver(), abi_serializer::create_yield_function(abi_serializer_max_time));
 
    // propose action
-   push_action( N(alice), N(propose), mvo()
+   push_action( "alice"_n, "propose"_n, mvo()
                   ("proposer",      "alice")
                   ("proposal_name", "first")
                   ("trx",           trx)
@@ -611,21 +611,21 @@ BOOST_FIXTURE_TEST_CASE( update_system_contract_major_approve, eosio_msig_tester
    );
 
    //approve by alice
-   push_action( N(alice), N(approve), mvo()
+   push_action( "alice"_n, "approve"_n, mvo()
                   ("proposer",      "alice")
                   ("proposal_name", "first")
-                  ("level",         permission_level{ N(alice), config::active_name })
+                  ("level",         permission_level{ "alice"_n, config::active_name })
    );
    //approve by bob
-   push_action( N(bob), N(approve), mvo()
+   push_action( "bob"_n, "approve"_n, mvo()
                   ("proposer",      "alice")
                   ("proposal_name", "first")
-                  ("level",         permission_level{ N(bob), config::active_name })
+                  ("level",         permission_level{ "bob"_n, config::active_name })
    );
 
    // not enough approvers
    BOOST_REQUIRE_EXCEPTION(
-      push_action( N(alice), N(exec), mvo()
+      push_action( "alice"_n, "exec"_n, mvo()
                      ("proposer",      "alice")
                      ("proposal_name", "first")
                      ("executer",      "alice")
@@ -634,10 +634,10 @@ BOOST_FIXTURE_TEST_CASE( update_system_contract_major_approve, eosio_msig_tester
    );
 
    //approve by apple
-   push_action( N(apple), N(approve), mvo()
+   push_action( "apple"_n, "approve"_n, mvo()
                   ("proposer",      "alice")
                   ("proposal_name", "first")
-                  ("level",         permission_level{ N(apple), config::active_name })
+                  ("level",         permission_level{ "apple"_n, config::active_name })
    );
    // execute by alice to replace the eosio system contract
    transaction_trace_ptr trace;
@@ -648,7 +648,7 @@ BOOST_FIXTURE_TEST_CASE( update_system_contract_major_approve, eosio_msig_tester
    } );
 
    // execute by another producer different from proposer
-   push_action( N(apple), N(exec), mvo()
+   push_action( "apple"_n, "exec"_n, mvo()
                   ("proposer",      "alice")
                   ("proposal_name", "first")
                   ("executer",      "apple")
@@ -660,24 +660,24 @@ BOOST_FIXTURE_TEST_CASE( update_system_contract_major_approve, eosio_msig_tester
 
    // can't create account because system contract was replaced by the reject_all contract
 
-   BOOST_REQUIRE_EXCEPTION( create_account_with_resources( N(alice1111112), N(eosio), core_sym::from_string("1.0000"), false ),
+   BOOST_REQUIRE_EXCEPTION( create_account_with_resources( "alice1111112"_n, "eosio"_n, core_sym::from_string("1.0000"), false ),
                             eosio_assert_message_exception, eosio_assert_message_is("rejecting all actions")
 
    );
 } FC_LOG_AND_RETHROW()
 
 BOOST_FIXTURE_TEST_CASE( propose_approve_invalidate, eosio_msig_tester ) try {
-   auto trx = reqauth( N(alice), {permission_level{N(alice), config::active_name}}, abi_serializer_max_time );
+   auto trx = reqauth( "alice"_n, {permission_level{"alice"_n, config::active_name}}, abi_serializer_max_time );
 
-   push_action( N(alice), N(propose), mvo()
+   push_action( "alice"_n, "propose"_n, mvo()
                   ("proposer",      "alice")
                   ("proposal_name", "first")
                   ("trx",           trx)
-                  ("requested", vector<permission_level>{{ N(alice), config::active_name }})
+                  ("requested", vector<permission_level>{{ "alice"_n, config::active_name }})
    );
 
    //fail to execute before approval
-   BOOST_REQUIRE_EXCEPTION( push_action( N(alice), N(exec), mvo()
+   BOOST_REQUIRE_EXCEPTION( push_action( "alice"_n, "exec"_n, mvo()
                                           ("proposer",      "alice")
                                           ("proposal_name", "first")
                                           ("executer",      "alice")
@@ -687,19 +687,19 @@ BOOST_FIXTURE_TEST_CASE( propose_approve_invalidate, eosio_msig_tester ) try {
    );
 
    //approve
-   push_action( N(alice), N(approve), mvo()
+   push_action( "alice"_n, "approve"_n, mvo()
                   ("proposer",      "alice")
                   ("proposal_name", "first")
-                  ("level",         permission_level{ N(alice), config::active_name })
+                  ("level",         permission_level{ "alice"_n, config::active_name })
    );
 
    //invalidate
-   push_action( N(alice), N(invalidate), mvo()
+   push_action( "alice"_n, "invalidate"_n, mvo()
                   ("account",      "alice")
    );
 
    //fail to execute after invalidation
-   BOOST_REQUIRE_EXCEPTION( push_action( N(alice), N(exec), mvo()
+   BOOST_REQUIRE_EXCEPTION( push_action( "alice"_n, "exec"_n, mvo()
                                           ("proposer",      "alice")
                                           ("proposal_name", "first")
                                           ("executer",      "alice")
@@ -710,17 +710,17 @@ BOOST_FIXTURE_TEST_CASE( propose_approve_invalidate, eosio_msig_tester ) try {
 } FC_LOG_AND_RETHROW()
 
 BOOST_FIXTURE_TEST_CASE( propose_invalidate_approve, eosio_msig_tester ) try {
-   auto trx = reqauth( N(alice), {permission_level{N(alice), config::active_name}}, abi_serializer_max_time );
+   auto trx = reqauth( "alice"_n, {permission_level{"alice"_n, config::active_name}}, abi_serializer_max_time );
 
-   push_action( N(alice), N(propose), mvo()
+   push_action( "alice"_n, "propose"_n, mvo()
                   ("proposer",      "alice")
                   ("proposal_name", "first")
                   ("trx",           trx)
-                  ("requested", vector<permission_level>{{ N(alice), config::active_name }})
+                  ("requested", vector<permission_level>{{ "alice"_n, config::active_name }})
    );
 
    //fail to execute before approval
-   BOOST_REQUIRE_EXCEPTION( push_action( N(alice), N(exec), mvo()
+   BOOST_REQUIRE_EXCEPTION( push_action( "alice"_n, "exec"_n, mvo()
                                           ("proposer",      "alice")
                                           ("proposal_name", "first")
                                           ("executer",      "alice")
@@ -730,15 +730,15 @@ BOOST_FIXTURE_TEST_CASE( propose_invalidate_approve, eosio_msig_tester ) try {
    );
 
    //invalidate
-   push_action( N(alice), N(invalidate), mvo()
+   push_action( "alice"_n, "invalidate"_n, mvo()
                   ("account",      "alice")
    );
 
    //approve
-   push_action( N(alice), N(approve), mvo()
+   push_action( "alice"_n, "approve"_n, mvo()
                   ("proposer",      "alice")
                   ("proposal_name", "first")
-                  ("level",         permission_level{ N(alice), config::active_name })
+                  ("level",         permission_level{ "alice"_n, config::active_name })
    );
 
    //successfully execute
@@ -749,7 +749,7 @@ BOOST_FIXTURE_TEST_CASE( propose_invalidate_approve, eosio_msig_tester ) try {
       if( t->scheduled ) { trace = t; }
    } );
 
-   push_action( N(bob), N(exec), mvo()
+   push_action( "bob"_n, "exec"_n, mvo()
                   ("proposer",      "alice")
                   ("proposal_name", "first")
                   ("executer",      "bob")
@@ -761,28 +761,28 @@ BOOST_FIXTURE_TEST_CASE( propose_invalidate_approve, eosio_msig_tester ) try {
 } FC_LOG_AND_RETHROW()
 
 BOOST_FIXTURE_TEST_CASE( approve_execute_old, eosio_msig_tester ) try {
-   set_code( N(eosio.msig), contracts::util::msig_wasm_old() );
-   set_abi( N(eosio.msig), contracts::util::msig_abi_old().data() );
+   set_code( "eosio.msig"_n, contracts::util::msig_wasm_old() );
+   set_abi( "eosio.msig"_n, contracts::util::msig_abi_old().data() );
    produce_blocks();
 
    //propose with old version of eosio.msig
-   auto trx = reqauth( N(alice), {permission_level{N(alice), config::active_name}}, abi_serializer_max_time );
-   push_action( N(alice), N(propose), mvo()
+   auto trx = reqauth( "alice"_n, {permission_level{"alice"_n, config::active_name}}, abi_serializer_max_time );
+   push_action( "alice"_n, "propose"_n, mvo()
                   ("proposer",      "alice")
                   ("proposal_name", "first")
                   ("trx",           trx)
-                  ("requested", vector<permission_level>{{ N(alice), config::active_name }})
+                  ("requested", vector<permission_level>{{ "alice"_n, config::active_name }})
    );
 
-   set_code( N(eosio.msig), contracts::msig_wasm() );
-   set_abi( N(eosio.msig), contracts::msig_abi().data() );
+   set_code( "eosio.msig"_n, contracts::msig_wasm() );
+   set_abi( "eosio.msig"_n, contracts::msig_abi().data() );
    produce_blocks();
 
    //approve and execute with new version
-   push_action( N(alice), N(approve), mvo()
+   push_action( "alice"_n, "approve"_n, mvo()
                   ("proposer",      "alice")
                   ("proposal_name", "first")
-                  ("level",         permission_level{ N(alice), config::active_name })
+                  ("level",         permission_level{ "alice"_n, config::active_name })
    );
 
    transaction_trace_ptr trace;
@@ -792,7 +792,7 @@ BOOST_FIXTURE_TEST_CASE( approve_execute_old, eosio_msig_tester ) try {
       if( t->scheduled ) { trace = t; }
    } );
 
-   push_action( N(alice), N(exec), mvo()
+   push_action( "alice"_n, "exec"_n, mvo()
                   ("proposer",      "alice")
                   ("proposal_name", "first")
                   ("executer",      "alice")
@@ -806,38 +806,38 @@ BOOST_FIXTURE_TEST_CASE( approve_execute_old, eosio_msig_tester ) try {
 
 
 BOOST_FIXTURE_TEST_CASE( approve_unapprove_old, eosio_msig_tester ) try {
-   set_code( N(eosio.msig), contracts::util::msig_wasm_old() );
-   set_abi( N(eosio.msig), contracts::util::msig_abi_old().data() );
+   set_code( "eosio.msig"_n, contracts::util::msig_wasm_old() );
+   set_abi( "eosio.msig"_n, contracts::util::msig_abi_old().data() );
    produce_blocks();
 
    //propose with old version of eosio.msig
-   auto trx = reqauth( N(alice), {permission_level{N(alice), config::active_name}}, abi_serializer_max_time );
-   push_action( N(alice), N(propose), mvo()
+   auto trx = reqauth( "alice"_n, {permission_level{"alice"_n, config::active_name}}, abi_serializer_max_time );
+   push_action( "alice"_n, "propose"_n, mvo()
                   ("proposer",      "alice")
                   ("proposal_name", "first")
                   ("trx",           trx)
-                  ("requested", vector<permission_level>{{ N(alice), config::active_name }})
+                  ("requested", vector<permission_level>{{ "alice"_n, config::active_name }})
    );
 
    //approve with old version
-   push_action( N(alice), N(approve), mvo()
+   push_action( "alice"_n, "approve"_n, mvo()
                   ("proposer",      "alice")
                   ("proposal_name", "first")
-                  ("level",         permission_level{ N(alice), config::active_name })
+                  ("level",         permission_level{ "alice"_n, config::active_name })
    );
 
-   set_code( N(eosio.msig), contracts::msig_wasm() );
-   set_abi( N(eosio.msig), contracts::msig_abi().data() );
+   set_code( "eosio.msig"_n, contracts::msig_wasm() );
+   set_abi( "eosio.msig"_n, contracts::msig_abi().data() );
    produce_blocks();
 
    //unapprove with old version
-   push_action( N(alice), N(unapprove), mvo()
+   push_action( "alice"_n, "unapprove"_n, mvo()
                   ("proposer",      "alice")
                   ("proposal_name", "first")
-                  ("level",         permission_level{ N(alice), config::active_name })
+                  ("level",         permission_level{ "alice"_n, config::active_name })
    );
 
-   BOOST_REQUIRE_EXCEPTION( push_action( N(alice), N(exec), mvo()
+   BOOST_REQUIRE_EXCEPTION( push_action( "alice"_n, "exec"_n, mvo()
                                           ("proposer",      "alice")
                                           ("proposal_name", "first")
                                           ("executer",      "alice")
@@ -849,31 +849,31 @@ BOOST_FIXTURE_TEST_CASE( approve_unapprove_old, eosio_msig_tester ) try {
 } FC_LOG_AND_RETHROW()
 
 BOOST_FIXTURE_TEST_CASE( approve_by_two_old, eosio_msig_tester ) try {
-   set_code( N(eosio.msig), contracts::util::msig_wasm_old() );
-   set_abi( N(eosio.msig), contracts::util::msig_abi_old().data() );
+   set_code( "eosio.msig"_n, contracts::util::msig_wasm_old() );
+   set_abi( "eosio.msig"_n, contracts::util::msig_abi_old().data() );
    produce_blocks();
 
-   auto trx = reqauth( N(alice), vector<permission_level>{ { N(alice), config::active_name }, { N(bob), config::active_name } }, abi_serializer_max_time );
-   push_action( N(alice), N(propose), mvo()
+   auto trx = reqauth( "alice"_n, vector<permission_level>{ { "alice"_n, config::active_name }, { "bob"_n, config::active_name } }, abi_serializer_max_time );
+   push_action( "alice"_n, "propose"_n, mvo()
                   ("proposer",      "alice")
                   ("proposal_name", "first")
                   ("trx",           trx)
-                  ("requested", vector<permission_level>{ { N(alice), config::active_name }, { N(bob), config::active_name } })
+                  ("requested", vector<permission_level>{ { "alice"_n, config::active_name }, { "bob"_n, config::active_name } })
    );
 
    //approve by alice
-   push_action( N(alice), N(approve), mvo()
+   push_action( "alice"_n, "approve"_n, mvo()
                   ("proposer",      "alice")
                   ("proposal_name", "first")
-                  ("level",         permission_level{ N(alice), config::active_name })
+                  ("level",         permission_level{ "alice"_n, config::active_name })
    );
 
-   set_code( N(eosio.msig), contracts::msig_wasm() );
-   set_abi( N(eosio.msig), contracts::msig_abi().data() );
+   set_code( "eosio.msig"_n, contracts::msig_wasm() );
+   set_abi( "eosio.msig"_n, contracts::msig_abi().data() );
    produce_blocks();
 
    //fail because approval by bob is missing
-   BOOST_REQUIRE_EXCEPTION( push_action( N(alice), N(exec), mvo()
+   BOOST_REQUIRE_EXCEPTION( push_action( "alice"_n, "exec"_n, mvo()
                                           ("proposer",      "alice")
                                           ("proposal_name", "first")
                                           ("executer",      "alice")
@@ -883,10 +883,10 @@ BOOST_FIXTURE_TEST_CASE( approve_by_two_old, eosio_msig_tester ) try {
    );
 
    //approve and execute with new version
-   push_action( N(bob), N(approve), mvo()
+   push_action( "bob"_n, "approve"_n, mvo()
                   ("proposer",      "alice")
                   ("proposal_name", "first")
-                  ("level",         permission_level{ N(bob), config::active_name })
+                  ("level",         permission_level{ "bob"_n, config::active_name })
    );
 
    transaction_trace_ptr trace;
@@ -896,7 +896,7 @@ BOOST_FIXTURE_TEST_CASE( approve_by_two_old, eosio_msig_tester ) try {
       if( t->scheduled ) { trace = t; }
    } );
 
-   push_action( N(alice), N(exec), mvo()
+   push_action( "alice"_n, "exec"_n, mvo()
                   ("proposer",      "alice")
                   ("proposal_name", "first")
                   ("executer",      "alice")
@@ -909,22 +909,22 @@ BOOST_FIXTURE_TEST_CASE( approve_by_two_old, eosio_msig_tester ) try {
 } FC_LOG_AND_RETHROW()
 
 BOOST_FIXTURE_TEST_CASE( approve_with_hash, eosio_msig_tester ) try {
-   auto trx = reqauth( N(alice), {permission_level{N(alice), config::active_name}}, abi_serializer_max_time );
+   auto trx = reqauth( "alice"_n, {permission_level{"alice"_n, config::active_name}}, abi_serializer_max_time );
    auto trx_hash = fc::sha256::hash( trx );
    auto not_trx_hash = fc::sha256::hash( trx_hash );
 
-   push_action( N(alice), N(propose), mvo()
+   push_action( "alice"_n, "propose"_n, mvo()
                   ("proposer",      "alice")
                   ("proposal_name", "first")
                   ("trx",           trx)
-                  ("requested", vector<permission_level>{{ N(alice), config::active_name }})
+                  ("requested", vector<permission_level>{{ "alice"_n, config::active_name }})
    );
 
    //fail to approve with incorrect hash
-   BOOST_REQUIRE_EXCEPTION( push_action( N(alice), N(approve), mvo()
+   BOOST_REQUIRE_EXCEPTION( push_action( "alice"_n, "approve"_n, mvo()
                                           ("proposer",      "alice")
                                           ("proposal_name", "first")
-                                          ("level",         permission_level{ N(alice), config::active_name })
+                                          ("level",         permission_level{ "alice"_n, config::active_name })
                                           ("proposal_hash", not_trx_hash)
                             ),
                             eosio::chain::crypto_api_exception,
@@ -932,10 +932,10 @@ BOOST_FIXTURE_TEST_CASE( approve_with_hash, eosio_msig_tester ) try {
    );
 
    //approve and execute
-   push_action( N(alice), N(approve), mvo()
+   push_action( "alice"_n, "approve"_n, mvo()
                   ("proposer",      "alice")
                   ("proposal_name", "first")
-                  ("level",         permission_level{ N(alice), config::active_name })
+                  ("level",         permission_level{ "alice"_n, config::active_name })
                   ("proposal_hash", trx_hash)
    );
 
@@ -946,7 +946,7 @@ BOOST_FIXTURE_TEST_CASE( approve_with_hash, eosio_msig_tester ) try {
       if( t->scheduled ) { trace = t; }
    } );
 
-   push_action( N(alice), N(exec), mvo()
+   push_action( "alice"_n, "exec"_n, mvo()
                   ("proposer",      "alice")
                   ("proposal_name", "first")
                   ("executer",      "alice")
@@ -958,40 +958,40 @@ BOOST_FIXTURE_TEST_CASE( approve_with_hash, eosio_msig_tester ) try {
 } FC_LOG_AND_RETHROW()
 
 BOOST_FIXTURE_TEST_CASE( switch_proposal_and_fail_approve_with_hash, eosio_msig_tester ) try {
-   auto trx1 = reqauth( N(alice), {permission_level{N(alice), config::active_name}}, abi_serializer_max_time );
+   auto trx1 = reqauth( "alice"_n, {permission_level{"alice"_n, config::active_name}}, abi_serializer_max_time );
    auto trx1_hash = fc::sha256::hash( trx1 );
 
-   push_action( N(alice), N(propose), mvo()
+   push_action( "alice"_n, "propose"_n, mvo()
                   ("proposer",      "alice")
                   ("proposal_name", "first")
                   ("trx",           trx1)
-                  ("requested", vector<permission_level>{{ N(alice), config::active_name }})
+                  ("requested", vector<permission_level>{{ "alice"_n, config::active_name }})
    );
 
-   auto trx2 = reqauth( N(alice),
-                       { permission_level{N(alice), config::active_name},
-                         permission_level{N(alice), config::owner_name}  },
+   auto trx2 = reqauth( "alice"_n,
+                       { permission_level{"alice"_n, config::active_name},
+                         permission_level{"alice"_n, config::owner_name}  },
                        abi_serializer_max_time );
 
-   push_action( N(alice), N(cancel), mvo()
+   push_action( "alice"_n, "cancel"_n, mvo()
                   ("proposer",      "alice")
                   ("proposal_name", "first")
                   ("canceler",       "alice")
    );
 
-   push_action( N(alice), N(propose), mvo()
+   push_action( "alice"_n, "propose"_n, mvo()
                   ("proposer",      "alice")
                   ("proposal_name", "first")
                   ("trx",           trx2)
-                  ("requested", vector<permission_level>{ { N(alice), config::active_name },
-                                                          { N(alice), config::owner_name } })
+                  ("requested", vector<permission_level>{ { "alice"_n, config::active_name },
+                                                          { "alice"_n, config::owner_name } })
    );
 
    //fail to approve with hash meant for old proposal
-   BOOST_REQUIRE_EXCEPTION( push_action( N(alice), N(approve), mvo()
+   BOOST_REQUIRE_EXCEPTION( push_action( "alice"_n, "approve"_n, mvo()
                                           ("proposer",      "alice")
                                           ("proposal_name", "first")
-                                          ("level",         permission_level{ N(alice), config::active_name })
+                                          ("level",         permission_level{ "alice"_n, config::active_name })
                                           ("proposal_hash", trx1_hash)
                             ),
                             eosio::chain::crypto_api_exception,

--- a/tests/eosio.powerup_tests.cpp
+++ b/tests/eosio.powerup_tests.cpp
@@ -16,24 +16,24 @@ inline constexpr int64_t powerup_frac  = 1'000'000'000'000'000ll; // 1.0 = 10^15
 inline constexpr int64_t stake_weight = 100'000'000'0000ll; // 10^12
 
 struct powerup_config_resource {
-   fc::optional<int64_t>        current_weight_ratio = {};
-   fc::optional<int64_t>        target_weight_ratio  = {};
-   fc::optional<int64_t>        assumed_stake_weight = {};
-   fc::optional<time_point_sec> target_timestamp     = {};
-   fc::optional<double>         exponent             = {};
-   fc::optional<uint32_t>       decay_secs           = {};
-   fc::optional<asset>          min_price            = {};
-   fc::optional<asset>          max_price            = {};
+   std::optional<int64_t>        current_weight_ratio = {};
+   std::optional<int64_t>        target_weight_ratio  = {};
+   std::optional<int64_t>        assumed_stake_weight = {};
+   std::optional<time_point_sec> target_timestamp     = {};
+   std::optional<double>         exponent             = {};
+   std::optional<uint32_t>       decay_secs           = {};
+   std::optional<asset>          min_price            = {};
+   std::optional<asset>          max_price            = {};
 };
 FC_REFLECT(powerup_config_resource,                                                             //
            (current_weight_ratio)(target_weight_ratio)(assumed_stake_weight)(target_timestamp) //
            (exponent)(decay_secs)(min_price)(max_price))
 
 struct powerup_config {
-   powerup_config_resource net          = {};
-   powerup_config_resource cpu          = {};
-   fc::optional<uint32_t> powerup_days    = {};
-   fc::optional<asset>    min_powerup_fee = {};
+   powerup_config_resource net             = {};
+   powerup_config_resource cpu             = {};
+   std::optional<uint32_t> powerup_days    = {};
+   std::optional<asset>    min_powerup_fee = {};
 };
 FC_REFLECT(powerup_config, (net)(cpu)(powerup_days)(min_powerup_fee))
 
@@ -72,22 +72,22 @@ using namespace eosio_system;
 
 struct powerup_tester : eosio_system_tester {
 
-   powerup_tester() { create_accounts_with_resources({ N(eosio.reserv) }); }
+   powerup_tester() { create_accounts_with_resources({ "eosio.reserv"_n }); }
 
    void start_rex() {
-      create_account_with_resources(N(rexholder111), config::system_account_name, core_sym::from_string("1.0000"),
+      create_account_with_resources("rexholder111"_n, config::system_account_name, core_sym::from_string("1.0000"),
                                     false);
-      transfer(config::system_account_name, N(rexholder111), core_sym::from_string("1001.0000"));
-      BOOST_REQUIRE_EQUAL("", stake(N(rexholder111), N(rexholder111), core_sym::from_string("500.0000"),
+      transfer(config::system_account_name, "rexholder111"_n, core_sym::from_string("1001.0000"));
+      BOOST_REQUIRE_EQUAL("", stake("rexholder111"_n, "rexholder111"_n, core_sym::from_string("500.0000"),
                                     core_sym::from_string("500.0000")));
-      create_account_with_resources(N(proxyaccount), config::system_account_name, core_sym::from_string("1.0000"),
+      create_account_with_resources("proxyaccount"_n, config::system_account_name, core_sym::from_string("1.0000"),
                                     false, core_sym::from_string("500.0000"), core_sym::from_string("500.0000"));
       BOOST_REQUIRE_EQUAL("",
-                          push_action(N(proxyaccount), N(regproxy), mvo()("proxy", "proxyaccount")("isproxy", true)));
-      BOOST_REQUIRE_EQUAL("", vote(N(rexholder111), {}, N(proxyaccount)));
-      BOOST_REQUIRE_EQUAL("", push_action(N(rexholder111), N(deposit),
+                          push_action("proxyaccount"_n, "regproxy"_n, mvo()("proxy", "proxyaccount")("isproxy", true)));
+      BOOST_REQUIRE_EQUAL("", vote("rexholder111"_n, {}, "proxyaccount"_n));
+      BOOST_REQUIRE_EQUAL("", push_action("rexholder111"_n, "deposit"_n,
                                           mvo()("owner", "rexholder111")("amount", asset::from_string("1.0000 TST"))));
-      BOOST_REQUIRE_EQUAL("", push_action(N(rexholder111), N(buyrex),
+      BOOST_REQUIRE_EQUAL("", push_action("rexholder111"_n, "buyrex"_n,
                                           mvo()("from", "rexholder111")("amount", asset::from_string("1.0000 TST"))));
    }
 
@@ -158,25 +158,25 @@ struct powerup_tester : eosio_system_tester {
       ;
 
       //idump((fc::json::to_pretty_string(conf)));
-      return push_action(config::system_account_name, N(cfgpowerup), mvo()("args", std::move(conf)));
+      return push_action(config::system_account_name, "cfgpowerup"_n, mvo()("args", std::move(conf)));
 
       // If abi_serializer worked correctly, the following is all that would be needed:
-      //return push_action(config::system_account_name, N(cfgpowerup), mvo()("args", config));
+      //return push_action(config::system_account_name, "cfgpowerup"_n, mvo()("args", config));
    }
 
    action_result powerupexec(name user, uint16_t max) {
-      return push_action(user, N(powerupexec), mvo()("user", user)("max", max));
+      return push_action(user, "powerupexec"_n, mvo()("user", user)("max", max));
    }
 
    action_result powerup(const name& payer, const name& receiver, uint32_t days, int64_t net_frac, int64_t cpu_frac,
                         const asset& max_payment) {
-      return push_action(payer, N(powerup),
+      return push_action(payer, "powerup"_n,
                          mvo()("payer", payer)("receiver", receiver)("days", days)("net_frac", net_frac)(
                                "cpu_frac", cpu_frac)("max_payment", max_payment));
    }
 
    powerup_state get_state() {
-      vector<char> data = get_row_by_account(config::system_account_name, {}, N(powup.state), N(powup.state));
+      vector<char> data = get_row_by_account(config::system_account_name, {}, "powup.state"_n, "powup.state"_n);
       return fc::raw::unpack<powerup_state>(data);
    }
 
@@ -198,12 +198,12 @@ struct powerup_tester : eosio_system_tester {
                      const asset& expected_fee, int64_t expected_net, int64_t expected_cpu) {
       auto before_payer    = get_account_info(payer);
       auto before_receiver = get_account_info(receiver);
-      auto before_reserve  = get_account_info(N(eosio.reserv));
+      auto before_reserve  = get_account_info("eosio.reserv"_n);
       auto before_state    = get_state();
       BOOST_REQUIRE_EQUAL("", powerup(payer, receiver, days, net_frac, cpu_frac, expected_fee));
       auto after_payer    = get_account_info(payer);
       auto after_receiver = get_account_info(receiver);
-      auto after_reserve  = get_account_info(N(eosio.reserv));
+      auto after_reserve  = get_account_info("eosio.reserv"_n);
       auto after_state    = get_state();
 
       if (false) {
@@ -256,8 +256,8 @@ BOOST_AUTO_TEST_SUITE(eosio_system_powerup_tests)
 
 BOOST_FIXTURE_TEST_CASE(config_tests, powerup_tester) try {
    BOOST_REQUIRE_EQUAL("missing authority of eosio",
-                       push_action(N(alice1111111), N(cfgpowerup), mvo()("args", make_config())));
-   BOOST_REQUIRE_EQUAL(wasm_assert_msg("powerup hasn't been initialized"), powerupexec(N(alice1111111), 10));
+                       push_action("alice1111111"_n, "cfgpowerup"_n, mvo()("args", make_config())));
+   BOOST_REQUIRE_EQUAL(wasm_assert_msg("powerup hasn't been initialized"), powerupexec("alice1111111"_n, 10));
 
    BOOST_REQUIRE_EQUAL(wasm_assert_msg("powerup_days must be > 0"),
                        configbw(make_config([&](auto& c) { c.powerup_days = 0; })));
@@ -496,7 +496,7 @@ BOOST_AUTO_TEST_CASE(rent_tests) try {
       t.produce_block();
 
       BOOST_REQUIRE_EQUAL(t.wasm_assert_msg("powerup hasn't been initialized"), //
-                          t.powerup(N(bob111111111), N(alice1111111), 30, powerup_frac / 4, powerup_frac / 8,
+                          t.powerup("bob111111111"_n, "alice1111111"_n, 30, powerup_frac / 4, powerup_frac / 8,
                                    asset::from_string("1.000 TST")));
 
       BOOST_REQUIRE_EQUAL("", t.configbw(t.make_config([&](auto& config) {
@@ -520,13 +520,13 @@ BOOST_AUTO_TEST_CASE(rent_tests) try {
 
       BOOST_REQUIRE_EQUAL(
             t.wasm_assert_msg("max_payment doesn't match core symbol"), //
-            t.powerup(N(bob111111111), N(alice1111111), 30, powerup_frac, powerup_frac, asset::from_string("1.000 TST")));
+            t.powerup("bob111111111"_n, "alice1111111"_n, 30, powerup_frac, powerup_frac, asset::from_string("1.000 TST")));
       BOOST_REQUIRE_EQUAL(
             t.wasm_assert_msg("market doesn't have resources available"), //
-            t.powerup(N(bob111111111), N(alice1111111), 30, 0, powerup_frac, asset::from_string("1.0000 TST")));
+            t.powerup("bob111111111"_n, "alice1111111"_n, 30, 0, powerup_frac, asset::from_string("1.0000 TST")));
       BOOST_REQUIRE_EQUAL(
             t.wasm_assert_msg("market doesn't have resources available"), //
-            t.powerup(N(bob111111111), N(alice1111111), 30, powerup_frac, 0, asset::from_string("1.0000 TST")));
+            t.powerup("bob111111111"_n, "alice1111111"_n, 30, powerup_frac, 0, asset::from_string("1.0000 TST")));
 
       BOOST_REQUIRE_EQUAL("", t.configbw(t.make_default_config([&](auto& config) {
          // weight = stake_weight
@@ -542,15 +542,15 @@ BOOST_AUTO_TEST_CASE(rent_tests) try {
       auto cpu_weight = stake_weight;
 
       t.start_rex();
-      t.create_account_with_resources(N(aaaaaaaaaaaa), config::system_account_name, core_sym::from_string("1.0000"),
+      t.create_account_with_resources("aaaaaaaaaaaa"_n, config::system_account_name, core_sym::from_string("1.0000"),
                                       false, core_sym::from_string("500.0000"), core_sym::from_string("500.0000"));
 
       // 10%, 20%
       // (.1) * 1000000.0000 = 100000.0000
       // (.2) * 1000000.0000 = 200000.0000
       //               total = 300000.0000
-      t.transfer(config::system_account_name, N(aaaaaaaaaaaa), core_sym::from_string("300000.0000"));
-      t.check_powerup(N(aaaaaaaaaaaa), N(aaaaaaaaaaaa), 30, powerup_frac * .1, powerup_frac * .2,
+      t.transfer(config::system_account_name, "aaaaaaaaaaaa"_n, core_sym::from_string("300000.0000"));
+      t.check_powerup("aaaaaaaaaaaa"_n, "aaaaaaaaaaaa"_n, 30, powerup_frac * .1, powerup_frac * .2,
                      asset::from_string("300000.0000 TST"), net_weight * .1, cpu_weight * .2);
 
       // Start decay
@@ -571,8 +571,8 @@ BOOST_AUTO_TEST_CASE(rent_tests) try {
       // (0.0135 + 0.02 - 0.0135) * 1000000.0000 = 20000.0000
       // (.02) * 1000000.0000                    = 20000.0000
       //                                   total = 40000.0000
-      t.transfer(config::system_account_name, N(aaaaaaaaaaaa), core_sym::from_string("40000.0001"));
-      t.check_powerup(N(aaaaaaaaaaaa), N(aaaaaaaaaaaa), 30, powerup_frac * .02, powerup_frac * .02,
+      t.transfer(config::system_account_name, "aaaaaaaaaaaa"_n, core_sym::from_string("40000.0001"));
+      t.check_powerup("aaaaaaaaaaaa"_n, "aaaaaaaaaaaa"_n, 30, powerup_frac * .02, powerup_frac * .02,
                      asset::from_string("40000.0001 TST"), net_weight * .02, cpu_weight * .02);
    }
 
@@ -600,9 +600,9 @@ BOOST_AUTO_TEST_CASE(rent_tests) try {
       if (rex)
          t.start_rex();
 
-      t.create_account_with_resources(N(aaaaaaaaaaaa), config::system_account_name, core_sym::from_string("1.0000"),
+      t.create_account_with_resources("aaaaaaaaaaaa"_n, config::system_account_name, core_sym::from_string("1.0000"),
                                       false, core_sym::from_string("500.0000"), core_sym::from_string("500.0000"));
-      t.create_account_with_resources(N(bbbbbbbbbbbb), config::system_account_name, core_sym::from_string("1.0000"),
+      t.create_account_with_resources("bbbbbbbbbbbb"_n, config::system_account_name, core_sym::from_string("1.0000"),
                                       false, core_sym::from_string("500.0000"), core_sym::from_string("500.0000"));
    };
    auto net_weight = stake_weight * 3;
@@ -613,28 +613,28 @@ BOOST_AUTO_TEST_CASE(rent_tests) try {
       init(t, false);
       BOOST_REQUIRE_EQUAL(
             t.wasm_assert_msg("days doesn't match configuration"), //
-            t.powerup(N(bob111111111), N(alice1111111), 20, powerup_frac, powerup_frac, asset::from_string("1.0000 TST")));
+            t.powerup("bob111111111"_n, "alice1111111"_n, 20, powerup_frac, powerup_frac, asset::from_string("1.0000 TST")));
       BOOST_REQUIRE_EQUAL(                                   //
             t.wasm_assert_msg("net_frac can't be negative"), //
-            t.powerup(N(bob111111111), N(alice1111111), 30, -powerup_frac, powerup_frac,
+            t.powerup("bob111111111"_n, "alice1111111"_n, 30, -powerup_frac, powerup_frac,
                      asset::from_string("1.0000 TST")));
       BOOST_REQUIRE_EQUAL(                                   //
             t.wasm_assert_msg("cpu_frac can't be negative"), //
-            t.powerup(N(bob111111111), N(alice1111111), 30, powerup_frac, -powerup_frac,
+            t.powerup("bob111111111"_n, "alice1111111"_n, 30, powerup_frac, -powerup_frac,
                      asset::from_string("1.0000 TST")));
       BOOST_REQUIRE_EQUAL(                                    //
             t.wasm_assert_msg("net can't be more than 100%"), //
-            t.powerup(N(bob111111111), N(alice1111111), 30, powerup_frac + 1, powerup_frac,
+            t.powerup("bob111111111"_n, "alice1111111"_n, 30, powerup_frac + 1, powerup_frac,
                      asset::from_string("1.0000 TST")));
       BOOST_REQUIRE_EQUAL(                                    //
             t.wasm_assert_msg("cpu can't be more than 100%"), //
-            t.powerup(N(bob111111111), N(alice1111111), 30, powerup_frac, powerup_frac + 1,
+            t.powerup("bob111111111"_n, "alice1111111"_n, 30, powerup_frac, powerup_frac + 1,
                      asset::from_string("1.0000 TST")));
       BOOST_REQUIRE_EQUAL(
             t.wasm_assert_msg("max_payment is less than calculated fee: 3000000.0000 TST"), //
-            t.powerup(N(bob111111111), N(alice1111111), 30, powerup_frac, powerup_frac, asset::from_string("1.0000 TST")));
+            t.powerup("bob111111111"_n, "alice1111111"_n, 30, powerup_frac, powerup_frac, asset::from_string("1.0000 TST")));
       BOOST_REQUIRE_EQUAL(t.wasm_assert_msg("can't channel fees to rex"), //
-                          t.powerup(N(bob111111111), N(alice1111111), 30, powerup_frac, powerup_frac,
+                          t.powerup("bob111111111"_n, "alice1111111"_n, 30, powerup_frac, powerup_frac,
                                    asset::from_string("3000000.0000 TST")));
    }
 
@@ -642,11 +642,11 @@ BOOST_AUTO_TEST_CASE(rent_tests) try {
    {
       powerup_tester t;
       init(t, true);
-      t.transfer(config::system_account_name, N(aaaaaaaaaaaa), core_sym::from_string("3000000.0000"));
+      t.transfer(config::system_account_name, "aaaaaaaaaaaa"_n, core_sym::from_string("3000000.0000"));
       BOOST_REQUIRE_EQUAL(
             t.wasm_assert_msg("calculated fee is below minimum; try powering up with more resources"),
-            t.powerup(N(aaaaaaaaaaaa), N(bbbbbbbbbbbb), 30, 10, 10, asset::from_string("3000000.0000 TST")));
-      t.check_powerup(N(aaaaaaaaaaaa), N(bbbbbbbbbbbb), 30, powerup_frac, powerup_frac,
+            t.powerup("aaaaaaaaaaaa"_n, "bbbbbbbbbbbb"_n, 30, 10, 10, asset::from_string("3000000.0000 TST")));
+      t.check_powerup("aaaaaaaaaaaa"_n, "bbbbbbbbbbbb"_n, 30, powerup_frac, powerup_frac,
                      asset::from_string("3000000.0000 TST"), net_weight, cpu_weight);
 
       BOOST_REQUIRE_EQUAL( //
@@ -682,15 +682,15 @@ BOOST_AUTO_TEST_CASE(rent_tests) try {
       // (.3 ^ 2) * 2000000.0000 / 2 =  90000.0000
       // (.4 ^ 3) * 6000000.0000 / 3 = 128000.0000
       //                       total = 218000.0000
-      t.transfer(config::system_account_name, N(aaaaaaaaaaaa), core_sym::from_string("218000.0001"));
-      t.check_powerup(N(aaaaaaaaaaaa), N(bbbbbbbbbbbb), 30, powerup_frac * .3, powerup_frac * .4,
+      t.transfer(config::system_account_name, "aaaaaaaaaaaa"_n, core_sym::from_string("218000.0001"));
+      t.check_powerup("aaaaaaaaaaaa"_n, "bbbbbbbbbbbb"_n, 30, powerup_frac * .3, powerup_frac * .4,
                      asset::from_string("218000.0001 TST"), net_weight * .3, cpu_weight * .4);
 
       // (.35 ^ 2) * 2000000.0000 / 2 -  90000.0000 =  32500.0000
       // (.5  ^ 3) * 6000000.0000 / 3 - 128000.0000 = 122000.0000
       //                                      total = 154500.0000
-      t.transfer(config::system_account_name, N(aaaaaaaaaaaa), core_sym::from_string("154500.0000"));
-      t.check_powerup(N(aaaaaaaaaaaa), N(bbbbbbbbbbbb), 30, powerup_frac * .05, powerup_frac * .10,
+      t.transfer(config::system_account_name, "aaaaaaaaaaaa"_n, core_sym::from_string("154500.0000"));
+      t.check_powerup("aaaaaaaaaaaa"_n, "bbbbbbbbbbbb"_n, 30, powerup_frac * .05, powerup_frac * .10,
                      asset::from_string("154500.0000 TST"), net_weight * .05, cpu_weight * .10);
    }
 
@@ -725,8 +725,8 @@ BOOST_AUTO_TEST_CASE(rent_tests) try {
       // 1200000.0000 * .5 +  (800000.0000 / 2) * (.5 ^ 2) =  700000.0000
       // 4000000.0000 * .5 + (2000000.0000 / 2) * (.5 ^ 2) = 2250000.0000
       //                                             total = 2950000.0000
-      t.transfer(config::system_account_name, N(aaaaaaaaaaaa), core_sym::from_string("2950000.0000"));
-      t.check_powerup(N(aaaaaaaaaaaa), N(bbbbbbbbbbbb), 30, powerup_frac * .5, powerup_frac * .5,
+      t.transfer(config::system_account_name, "aaaaaaaaaaaa"_n, core_sym::from_string("2950000.0000"));
+      t.check_powerup("aaaaaaaaaaaa"_n, "bbbbbbbbbbbb"_n, 30, powerup_frac * .5, powerup_frac * .5,
                      asset::from_string("2950000.0000 TST"), net_weight * .5, cpu_weight * .5);
    }
 
@@ -734,21 +734,21 @@ BOOST_AUTO_TEST_CASE(rent_tests) try {
       // net:100%, cpu:100%
       powerup_tester t;
       init(t, true);
-      t.transfer(config::system_account_name, N(aaaaaaaaaaaa), core_sym::from_string("3000000.0000"));
-      t.check_powerup(N(aaaaaaaaaaaa), N(bbbbbbbbbbbb), 30, powerup_frac, powerup_frac,
+      t.transfer(config::system_account_name, "aaaaaaaaaaaa"_n, core_sym::from_string("3000000.0000"));
+      t.check_powerup("aaaaaaaaaaaa"_n, "bbbbbbbbbbbb"_n, 30, powerup_frac, powerup_frac,
                      asset::from_string("3000000.0000 TST"), net_weight, cpu_weight);
 
       // No more available for 30 days
       BOOST_REQUIRE_EQUAL(t.wasm_assert_msg("market doesn't have enough resources available"), //
-                          t.powerup(N(bob111111111), N(alice1111111), 30, powerup_frac / 1000, powerup_frac / 1000,
+                          t.powerup("bob111111111"_n, "alice1111111"_n, 30, powerup_frac / 1000, powerup_frac / 1000,
                                    asset::from_string("1.0000 TST")));
       t.produce_block(fc::days(29));
       BOOST_REQUIRE_EQUAL(t.wasm_assert_msg("market doesn't have enough resources available"), //
-                          t.powerup(N(bob111111111), N(alice1111111), 30, powerup_frac / 1000, powerup_frac / 1000,
+                          t.powerup("bob111111111"_n, "alice1111111"_n, 30, powerup_frac / 1000, powerup_frac / 1000,
                                    asset::from_string("1.0000 TST")));
       t.produce_block(fc::days(1) - fc::milliseconds(1500));
       BOOST_REQUIRE_EQUAL(t.wasm_assert_msg("market doesn't have enough resources available"), //
-                          t.powerup(N(bob111111111), N(alice1111111), 30, powerup_frac / 1000, powerup_frac / 1000,
+                          t.powerup("bob111111111"_n, "alice1111111"_n, 30, powerup_frac / 1000, powerup_frac / 1000,
                                    asset::from_string("1.0000 TST")));
       t.produce_block(fc::milliseconds(500));
 
@@ -757,21 +757,21 @@ BOOST_AUTO_TEST_CASE(rent_tests) try {
       // (1.0 ^ 1) * 2000000.0000 = 2000000.0000
       // (1.0 ^ 2) * 6000000.0000 = 6000000.0000
       //                    total = 8000000.0000
-      t.transfer(config::system_account_name, N(aaaaaaaaaaaa), core_sym::from_string("8000000.0000"));
-      t.check_powerup(N(aaaaaaaaaaaa), N(bbbbbbbbbbbb), 30, powerup_frac, powerup_frac,
+      t.transfer(config::system_account_name, "aaaaaaaaaaaa"_n, core_sym::from_string("8000000.0000"));
+      t.check_powerup("aaaaaaaaaaaa"_n, "bbbbbbbbbbbb"_n, 30, powerup_frac, powerup_frac,
                      asset::from_string("8000000.0000 TST"), 0, 0);
 
       // No more available for 30 days
       BOOST_REQUIRE_EQUAL(t.wasm_assert_msg("market doesn't have enough resources available"), //
-                          t.powerup(N(bob111111111), N(alice1111111), 30, powerup_frac / 1000, powerup_frac / 1000,
+                          t.powerup("bob111111111"_n, "alice1111111"_n, 30, powerup_frac / 1000, powerup_frac / 1000,
                                    asset::from_string("1.0000 TST")));
       t.produce_block(fc::days(29));
       BOOST_REQUIRE_EQUAL(t.wasm_assert_msg("market doesn't have enough resources available"), //
-                          t.powerup(N(bob111111111), N(alice1111111), 30, powerup_frac / 1000, powerup_frac / 1000,
+                          t.powerup("bob111111111"_n, "alice1111111"_n, 30, powerup_frac / 1000, powerup_frac / 1000,
                                    asset::from_string("1.0000 TST")));
       t.produce_block(fc::days(1) - fc::milliseconds(1000));
       BOOST_REQUIRE_EQUAL(t.wasm_assert_msg("market doesn't have enough resources available"), //
-                          t.powerup(N(bob111111111), N(alice1111111), 30, powerup_frac / 1000, powerup_frac / 1000,
+                          t.powerup("bob111111111"_n, "alice1111111"_n, 30, powerup_frac / 1000, powerup_frac / 1000,
                                    asset::from_string("1.0000 TST")));
 
       // Start decay
@@ -802,8 +802,8 @@ BOOST_AUTO_TEST_CASE(rent_tests) try {
       // [ ((e^-2) ^ 1)*(e^-2 - 0.0) + ((1.0) ^ 2)/2 - ((e^-2) ^ 2)/2 ] * 2000000.0000 = 1018315.6389
       // [ ((e^-2) ^ 2)*(e^-2 - 0.0) + ((1.0) ^ 3)/3 - ((e^-2) ^ 3)/3 ] * 6000000.0000 = 2009915.0087
       //                                                                         total = 3028230.6476
-      t.transfer(config::system_account_name, N(aaaaaaaaaaaa), core_sym::from_string("3028229.8795"));
-      t.check_powerup(N(aaaaaaaaaaaa), N(bbbbbbbbbbbb), 30, powerup_frac, powerup_frac,
+      t.transfer(config::system_account_name, "aaaaaaaaaaaa"_n, core_sym::from_string("3028229.8795"));
+      t.check_powerup("aaaaaaaaaaaa"_n, "bbbbbbbbbbbb"_n, 30, powerup_frac, powerup_frac,
                      asset::from_string("3028229.8795 TST"), net_weight, cpu_weight);
    }
 
@@ -815,8 +815,8 @@ BOOST_AUTO_TEST_CASE(rent_tests) try {
       // (.1 ^ 2) * 2000000.0000 / 2 = 10000.0000
       // (.2 ^ 3) * 6000000.0000 / 3 = 16000.0000
       //                       total = 26000.0000
-      t.transfer(config::system_account_name, N(aaaaaaaaaaaa), core_sym::from_string("26000.0002"));
-      t.check_powerup(N(aaaaaaaaaaaa), N(bbbbbbbbbbbb), 30, powerup_frac * .1, powerup_frac * .2,
+      t.transfer(config::system_account_name, "aaaaaaaaaaaa"_n, core_sym::from_string("26000.0002"));
+      t.check_powerup("aaaaaaaaaaaa"_n, "bbbbbbbbbbbb"_n, 30, powerup_frac * .1, powerup_frac * .2,
                      asset::from_string("26000.0002 TST"), net_weight * .1, cpu_weight * .2);
 
       t.produce_block(fc::days(15) - fc::milliseconds(500));
@@ -825,8 +825,8 @@ BOOST_AUTO_TEST_CASE(rent_tests) try {
       // (.3 ^ 2) * 2000000.0000 / 2 - 10000.0000 =  80000.0000
       // (.4 ^ 3) * 6000000.0000 / 3 - 16000.0000 = 112000.0000
       //                                    total = 192000.0000
-      t.transfer(config::system_account_name, N(aaaaaaaaaaaa), core_sym::from_string("192000.0001"));
-      t.check_powerup(N(aaaaaaaaaaaa), N(bbbbbbbbbbbb), 30, powerup_frac * .2, powerup_frac * .2,
+      t.transfer(config::system_account_name, "aaaaaaaaaaaa"_n, core_sym::from_string("192000.0001"));
+      t.check_powerup("aaaaaaaaaaaa"_n, "bbbbbbbbbbbb"_n, 30, powerup_frac * .2, powerup_frac * .2,
                      asset::from_string("192000.0001 TST"), net_weight * .2, cpu_weight * .2);
 
       // Start decay

--- a/tests/eosio.system_tester.hpp
+++ b/tests/eosio.system_tester.hpp
@@ -32,15 +32,15 @@ public:
    void basic_setup() {
       produce_blocks( 2 );
 
-      create_accounts({ N(eosio.token), N(eosio.ram), N(eosio.ramfee), N(eosio.stake),
-               N(eosio.bpay), N(eosio.vpay), N(eosio.saving), N(eosio.names), N(eosio.rex) });
+      create_accounts({ "eosio.token"_n, "eosio.ram"_n, "eosio.ramfee"_n, "eosio.stake"_n,
+               "eosio.bpay"_n, "eosio.vpay"_n, "eosio.saving"_n, "eosio.names"_n, "eosio.rex"_n });
 
 
       produce_blocks( 100 );
-      set_code( N(eosio.token), contracts::token_wasm());
-      set_abi( N(eosio.token), contracts::token_abi().data() );
+      set_code( "eosio.token"_n, contracts::token_wasm());
+      set_abi( "eosio.token"_n, contracts::token_abi().data() );
       {
-         const auto& accnt = control->db().get<account_object,by_name>( N(eosio.token) );
+         const auto& accnt = control->db().get<account_object,by_name>( "eosio.token"_n );
          abi_def abi;
          BOOST_REQUIRE_EQUAL(abi_serializer::to_abi(accnt.abi, abi), true);
          token_abi_ser.set_abi(abi, abi_serializer::create_yield_function(abi_serializer_max_time));
@@ -49,7 +49,7 @@ public:
 
    void create_core_token( symbol core_symbol = symbol{CORE_SYM} ) {
       FC_ASSERT( core_symbol.decimals() == 4, "create_core_token assumes core token has 4 digits of precision" );
-      create_currency( N(eosio.token), config::system_account_name, asset(100000000000000, core_symbol) );
+      create_currency( "eosio.token"_n, config::system_account_name, asset(100000000000000, core_symbol) );
       issue( asset(10000000000000, core_symbol) );
       BOOST_REQUIRE_EQUAL( asset(10000000000000, core_symbol), get_balance( "eosio", core_symbol ) );
    }
@@ -58,7 +58,7 @@ public:
       set_code( config::system_account_name, contracts::system_wasm() );
       set_abi( config::system_account_name, contracts::system_abi().data() );
       if( call_init ) {
-         base_tester::push_action(config::system_account_name, N(init),
+         base_tester::push_action(config::system_account_name, "init"_n,
                                                config::system_account_name,  mutable_variant_object()
                                                ("version", 0)
                                                ("core", CORE_SYM_STR)
@@ -77,9 +77,9 @@ public:
       produce_blocks();
 
       // Assumes previous setup steps were done with core token symbol set to CORE_SYM
-      create_account_with_resources( N(alice1111111), config::system_account_name, core_sym::from_string("1.0000"), false );
-      create_account_with_resources( N(bob111111111), config::system_account_name, core_sym::from_string("0.4500"), false );
-      create_account_with_resources( N(carol1111111), config::system_account_name, core_sym::from_string("1.0000"), false );
+      create_account_with_resources( "alice1111111"_n, config::system_account_name, core_sym::from_string("1.0000"), false );
+      create_account_with_resources( "bob111111111"_n, config::system_account_name, core_sym::from_string("0.4500"), false );
+      create_account_with_resources( "carol1111111"_n, config::system_account_name, core_sym::from_string("1.0000"), false );
 
       BOOST_REQUIRE_EQUAL( core_sym::from_string("1000000000.0000"), get_balance("eosio")  + get_balance("eosio.ramfee") + get_balance("eosio.stake") + get_balance("eosio.ram") );
    }
@@ -139,13 +139,13 @@ public:
                                    .active   = authority( get_public_key( a, "active" ) )
                                 });
 
-      trx.actions.emplace_back( get_action( config::system_account_name, N(buyrambytes), vector<permission_level>{{creator,config::active_name}},
+      trx.actions.emplace_back( get_action( config::system_account_name, "buyrambytes"_n, vector<permission_level>{{creator,config::active_name}},
                                             mvo()
                                             ("payer", creator)
                                             ("receiver", a)
                                             ("bytes", ram_bytes) )
                               );
-      trx.actions.emplace_back( get_action( config::system_account_name, N(delegatebw), vector<permission_level>{{creator,config::active_name}},
+      trx.actions.emplace_back( get_action( config::system_account_name, "delegatebw"_n, vector<permission_level>{{creator,config::active_name}},
                                             mvo()
                                             ("from", creator)
                                             ("receiver", a)
@@ -181,14 +181,14 @@ public:
                                    .active   = authority( get_public_key( a, "active" ) )
                                 });
 
-      trx.actions.emplace_back( get_action( config::system_account_name, N(buyram), vector<permission_level>{{creator,config::active_name}},
+      trx.actions.emplace_back( get_action( config::system_account_name, "buyram"_n, vector<permission_level>{{creator,config::active_name}},
                                             mvo()
                                             ("payer", creator)
                                             ("receiver", a)
                                             ("quant", ramfunds) )
                               );
 
-      trx.actions.emplace_back( get_action( config::system_account_name, N(delegatebw), vector<permission_level>{{creator,config::active_name}},
+      trx.actions.emplace_back( get_action( config::system_account_name, "delegatebw"_n, vector<permission_level>{{creator,config::active_name}},
                                             mvo()
                                             ("from", creator)
                                             ("receiver", a)
@@ -223,14 +223,14 @@ public:
                                          .active   = authority( get_public_key( a, "active" ) )
                                          });
 
-         trx.actions.emplace_back( get_action( config::system_account_name, N(buyram), vector<permission_level>{ {creator, config::active_name} },
+         trx.actions.emplace_back( get_action( config::system_account_name, "buyram"_n, vector<permission_level>{ {creator, config::active_name} },
                                                mvo()
                                                ("payer", creator)
                                                ("receiver", a)
                                                ("quant", ram) )
                                    );
 
-         trx.actions.emplace_back( get_action( config::system_account_name, N(delegatebw), vector<permission_level>{ {creator, config::active_name} },
+         trx.actions.emplace_back( get_action( config::system_account_name, "delegatebw"_n, vector<permission_level>{ {creator, config::active_name} },
                                                mvo()
                                                ("from", creator)
                                                ("receiver", a)
@@ -247,21 +247,21 @@ public:
    }
 
    action_result buyram( const account_name& payer, account_name receiver, const asset& eosin ) {
-      return push_action( payer, N(buyram), mvo()( "payer",payer)("receiver",receiver)("quant",eosin) );
+      return push_action( payer, "buyram"_n, mvo()( "payer",payer)("receiver",receiver)("quant",eosin) );
    }
    action_result buyram( std::string_view payer, std::string_view receiver, const asset& eosin ) {
       return buyram( account_name(payer), account_name(receiver), eosin );
    }
 
    action_result buyrambytes( const account_name& payer, account_name receiver, uint32_t numbytes ) {
-      return push_action( payer, N(buyrambytes), mvo()( "payer",payer)("receiver",receiver)("bytes",numbytes) );
+      return push_action( payer, "buyrambytes"_n, mvo()( "payer",payer)("receiver",receiver)("bytes",numbytes) );
    }
    action_result buyrambytes( std::string_view payer, std::string_view receiver, uint32_t numbytes ) {
       return buyrambytes( account_name(payer), account_name(receiver), numbytes );
    }
 
    action_result sellram( const account_name& account, uint64_t numbytes ) {
-      return push_action( account, N(sellram), mvo()( "account", account)("bytes",numbytes) );
+      return push_action( account, "sellram"_n, mvo()( "account", account)("bytes",numbytes) );
    }
    action_result sellram( std::string_view account, uint64_t numbytes ) {
       return sellram( account_name(account), numbytes );
@@ -275,11 +275,11 @@ public:
          act.name = name;
          act.data = abi_ser.variant_to_binary( action_type_name, data, abi_serializer::create_yield_function(abi_serializer_max_time) );
 
-         return base_tester::push_action( std::move(act), (auth ? signer : signer == N(bob111111111) ? N(alice1111111) : N(bob111111111)).to_uint64_t() );
+         return base_tester::push_action( std::move(act), (auth ? signer : signer == "bob111111111"_n ? "alice1111111"_n : "bob111111111"_n).to_uint64_t() );
    }
 
    action_result stake( const account_name& from, const account_name& to, const asset& net, const asset& cpu ) {
-      return push_action( name(from), N(delegatebw), mvo()
+      return push_action( name(from), "delegatebw"_n, mvo()
                           ("from",     from)
                           ("receiver", to)
                           ("stake_net_quantity", net)
@@ -299,7 +299,7 @@ public:
    }
 
    action_result stake_with_transfer( const account_name& from, const account_name& to, const asset& net, const asset& cpu ) {
-      return push_action( name(from), N(delegatebw), mvo()
+      return push_action( name(from), "delegatebw"_n, mvo()
                           ("from",     from)
                           ("receiver", to)
                           ("stake_net_quantity", net)
@@ -319,7 +319,7 @@ public:
    }
 
    action_result unstake( const account_name& from, const account_name& to, const asset& net, const asset& cpu ) {
-      return push_action( name(from), N(undelegatebw), mvo()
+      return push_action( name(from), "undelegatebw"_n, mvo()
                           ("from",     from)
                           ("receiver", to)
                           ("unstake_net_quantity", net)
@@ -352,31 +352,31 @@ public:
    };
 
    action_result deposit( const account_name& owner, const asset& amount ) {
-      return push_action( name(owner), N(deposit), mvo()
+      return push_action( name(owner), "deposit"_n, mvo()
                           ("owner",  owner)
                           ("amount", amount)
       );
    }
 
    action_result withdraw( const account_name& owner, const asset& amount ) {
-      return push_action( name(owner), N(withdraw), mvo()
+      return push_action( name(owner), "withdraw"_n, mvo()
                           ("owner",  owner)
                           ("amount", amount)
       );
    }
 
    action_result buyrex( const account_name& from, const asset& amount ) {
-      return push_action( name(from), N(buyrex), mvo()
+      return push_action( name(from), "buyrex"_n, mvo()
                           ("from",   from)
                           ("amount", amount)
       );
    }
 
    asset get_buyrex_result( const account_name& from, const asset& amount ) {
-      auto trace = base_tester::push_action( config::system_account_name, N(buyrex), from, mvo()("from", from)("amount", amount) );
+      auto trace = base_tester::push_action( config::system_account_name, "buyrex"_n, from, mvo()("from", from)("amount", amount) );
       asset rex_received;
       for ( size_t i = 0; i < trace->action_traces.size(); ++i ) {
-         if ( trace->action_traces[i].act.name == N(buyresult) ) {
+         if ( trace->action_traces[i].act.name == "buyresult"_n ) {
             fc::raw::unpack( trace->action_traces[i].act.data.data(),
                              trace->action_traces[i].act.data.size(),
                              rex_received );
@@ -387,7 +387,7 @@ public:
    }
 
    action_result unstaketorex( const account_name& owner, const account_name& receiver, const asset& from_net, const asset& from_cpu ) {
-      return push_action( name(owner), N(unstaketorex), mvo()
+      return push_action( name(owner), "unstaketorex"_n, mvo()
                           ("owner",    owner)
                           ("receiver", receiver)
                           ("from_net", from_net)
@@ -396,7 +396,7 @@ public:
    }
 
    asset get_unstaketorex_result( const account_name& owner, const account_name& receiver, const asset& from_net, const asset& from_cpu ) {
-      auto trace = base_tester::push_action( config::system_account_name, N(unstaketorex), owner, mvo()
+      auto trace = base_tester::push_action( config::system_account_name, "unstaketorex"_n, owner, mvo()
                                              ("owner", owner)
                                              ("receiver", receiver)
                                              ("from_net", from_net)
@@ -404,7 +404,7 @@ public:
       );
       asset rex_received;
       for ( size_t i = 0; i < trace->action_traces.size(); ++i ) {
-         if ( trace->action_traces[i].act.name == N(buyresult) ) {
+         if ( trace->action_traces[i].act.name == "buyresult"_n ) {
             fc::raw::unpack( trace->action_traces[i].act.data.data(),
                              trace->action_traces[i].act.data.size(),
                              rex_received );
@@ -415,17 +415,17 @@ public:
    }
 
    action_result sellrex( const account_name& from, const asset& rex ) {
-      return push_action( name(from), N(sellrex), mvo()
+      return push_action( name(from), "sellrex"_n, mvo()
                           ("from", from)
                           ("rex",  rex)
       );
    }
 
    asset get_sellrex_result( const account_name& from, const asset& rex ) {
-      auto trace = base_tester::push_action( config::system_account_name, N(sellrex), from, mvo()("from", from)("rex", rex) );
+      auto trace = base_tester::push_action( config::system_account_name, "sellrex"_n, from, mvo()("from", from)("rex", rex) );
       asset proceeds;
       for ( size_t i = 0; i < trace->action_traces.size(); ++i ) {
-         if ( trace->action_traces[i].act.name == N(sellresult) ) {
+         if ( trace->action_traces[i].act.name == "sellresult"_n ) {
             fc::raw::unpack( trace->action_traces[i].act.data.data(),
                              trace->action_traces[i].act.data.size(),
                              proceeds );
@@ -438,7 +438,7 @@ public:
    auto get_rexorder_result( const transaction_trace_ptr& trace ) {
       std::vector<std::pair<account_name, asset>> output;
       for ( size_t i = 0; i < trace->action_traces.size(); ++i ) {
-         if ( trace->action_traces[i].act.name == N(orderresult) ) {
+         if ( trace->action_traces[i].act.name == "orderresult"_n ) {
             fc::datastream<const char*> ds( trace->action_traces[i].act.data.data(),
                                             trace->action_traces[i].act.data.size() );
             account_name owner; fc::raw::unpack( ds, owner );
@@ -450,11 +450,11 @@ public:
    }
 
    action_result cancelrexorder( const account_name& owner ) {
-      return push_action( name(owner), N(cnclrexorder), mvo()("owner", owner) );
+      return push_action( name(owner), "cnclrexorder"_n, mvo()("owner", owner) );
    }
 
    action_result rentcpu( const account_name& from, const account_name& receiver, const asset& payment, const asset& fund = core_sym::from_string("0.0000") ) {
-      return push_action( name(from), N(rentcpu), mvo()
+      return push_action( name(from), "rentcpu"_n, mvo()
                           ("from",         from)
                           ("receiver",     receiver)
                           ("loan_payment", payment)
@@ -463,7 +463,7 @@ public:
    }
 
    action_result rentnet( const account_name& from, const account_name& receiver, const asset& payment, const asset& fund = core_sym::from_string("0.0000") ) {
-      return push_action( name(from), N(rentnet), mvo()
+      return push_action( name(from), "rentnet"_n, mvo()
                           ("from",         from)
                           ("receiver",     receiver)
                           ("loan_payment", payment)
@@ -472,7 +472,7 @@ public:
    }
 
    asset _get_rentrex_result( const account_name& from, const account_name& receiver, const asset& payment, bool cpu ) {
-      const name act = cpu ? N(rentcpu) : N(rentnet);
+      const name act = cpu ? "rentcpu"_n : "rentnet"_n;
       auto trace = base_tester::push_action( config::system_account_name, act, from, mvo()
                                              ("from",         from)
                                              ("receiver",     receiver)
@@ -482,7 +482,7 @@ public:
 
       asset rented_tokens = core_sym::from_string("0.0000");
       for ( size_t i = 0; i < trace->action_traces.size(); ++i ) {
-         if ( trace->action_traces[i].act.name == N(rentresult) ) {
+         if ( trace->action_traces[i].act.name == "rentresult"_n ) {
             fc::raw::unpack( trace->action_traces[i].act.data.data(),
                              trace->action_traces[i].act.data.size(),
                              rented_tokens );
@@ -501,7 +501,7 @@ public:
    }
 
    action_result fundcpuloan( const account_name& from, const uint64_t loan_num, const asset& payment ) {
-      return push_action( name(from), N(fundcpuloan), mvo()
+      return push_action( name(from), "fundcpuloan"_n, mvo()
                           ("from",       from)
                           ("loan_num",   loan_num)
                           ("payment",    payment)
@@ -509,7 +509,7 @@ public:
    }
 
    action_result fundnetloan( const account_name& from, const uint64_t loan_num, const asset& payment ) {
-      return push_action( name(from), N(fundnetloan), mvo()
+      return push_action( name(from), "fundnetloan"_n, mvo()
                           ("from",       from)
                           ("loan_num",   loan_num)
                           ("payment",    payment)
@@ -518,7 +518,7 @@ public:
 
 
    action_result defundcpuloan( const account_name& from, const uint64_t loan_num, const asset& amount ) {
-      return push_action( name(from), N(defcpuloan), mvo()
+      return push_action( name(from), "defcpuloan"_n, mvo()
                           ("from",     from)
                           ("loan_num", loan_num)
                           ("amount",   amount)
@@ -526,7 +526,7 @@ public:
    }
 
    action_result defundnetloan( const account_name& from, const uint64_t loan_num, const asset& amount ) {
-      return push_action( name(from), N(defnetloan), mvo()
+      return push_action( name(from), "defnetloan"_n, mvo()
                           ("from",     from)
                           ("loan_num", loan_num)
                           ("amount",   amount)
@@ -534,34 +534,34 @@ public:
    }
 
    action_result updaterex( const account_name& owner ) {
-      return push_action( name(owner), N(updaterex), mvo()("owner", owner) );
+      return push_action( name(owner), "updaterex"_n, mvo()("owner", owner) );
    }
 
    action_result rexexec( const account_name& user, uint16_t max ) {
-      return push_action( name(user), N(rexexec), mvo()("user", user)("max", max) );
+      return push_action( name(user), "rexexec"_n, mvo()("user", user)("max", max) );
    }
 
    action_result consolidate( const account_name& owner ) {
-      return push_action( name(owner), N(consolidate), mvo()("owner", owner) );
+      return push_action( name(owner), "consolidate"_n, mvo()("owner", owner) );
    }
 
    action_result mvtosavings( const account_name& owner, const asset& rex ) {
-      return push_action( name(owner), N(mvtosavings), mvo()("owner", owner)("rex", rex) );
+      return push_action( name(owner), "mvtosavings"_n, mvo()("owner", owner)("rex", rex) );
    }
 
    action_result mvfrsavings( const account_name& owner, const asset& rex ) {
-      return push_action( name(owner), N(mvfrsavings), mvo()("owner", owner)("rex", rex) );
+      return push_action( name(owner), "mvfrsavings"_n, mvo()("owner", owner)("rex", rex) );
    }
 
    action_result closerex( const account_name& owner ) {
-      return push_action( name(owner), N(closerex), mvo()("owner", owner) );
+      return push_action( name(owner), "closerex"_n, mvo()("owner", owner) );
    }
 
    fc::variant get_last_loan(bool cpu) {
       vector<char> data;
       const auto& db = control->db();
       namespace chain = eosio::chain;
-      auto table = cpu ? N(cpuloan) : N(netloan);
+      auto table = cpu ? "cpuloan"_n : "netloan"_n;
       const auto* t_id = db.find<eosio::chain::table_id_object, chain::by_code_scope_table>( boost::make_tuple( config::system_account_name, config::system_account_name, table ) );
       if ( !t_id ) {
          return fc::variant();
@@ -592,7 +592,7 @@ public:
    }
 
    fc::variant get_loan_info( const uint64_t& loan_num, bool cpu ) const {
-      name table_name = cpu ? N(cpuloan) : N(netloan);
+      name table_name = cpu ? "cpuloan"_n : "netloan"_n;
       vector<char> data = get_row_by_account( config::system_account_name, config::system_account_name, table_name, account_name(loan_num) );
       return data.empty() ? fc::variant() : abi_ser.binary_to_variant( "rex_loan", data, abi_serializer::create_yield_function(abi_serializer_max_time) );
    }
@@ -606,42 +606,42 @@ public:
    }
 
    fc::variant get_dbw_obj( const account_name& from, const account_name& receiver ) const {
-      vector<char> data = get_row_by_account( config::system_account_name, from, N(delband), receiver );
+      vector<char> data = get_row_by_account( config::system_account_name, from, "delband"_n, receiver );
       return data.empty() ? fc::variant() : abi_ser.binary_to_variant("delegated_bandwidth", data, abi_serializer::create_yield_function(abi_serializer_max_time));
    }
 
    asset get_rex_balance( const account_name& act ) const {
-      vector<char> data = get_row_by_account( config::system_account_name, config::system_account_name, N(rexbal), act );
+      vector<char> data = get_row_by_account( config::system_account_name, config::system_account_name, "rexbal"_n, act );
       return data.empty() ? asset(0, symbol(SY(4, REX))) : abi_ser.binary_to_variant("rex_balance", data, abi_serializer::create_yield_function(abi_serializer_max_time))["rex_balance"].as<asset>();
    }
 
    fc::variant get_rex_balance_obj( const account_name& act ) const {
-      vector<char> data = get_row_by_account( config::system_account_name, config::system_account_name, N(rexbal), act );
+      vector<char> data = get_row_by_account( config::system_account_name, config::system_account_name, "rexbal"_n, act );
       return data.empty() ? fc::variant() : abi_ser.binary_to_variant("rex_balance", data, abi_serializer::create_yield_function(abi_serializer_max_time));
    }
 
    asset get_rex_fund( const account_name& act ) const {
-      vector<char> data = get_row_by_account( config::system_account_name, config::system_account_name, N(rexfund), act );
+      vector<char> data = get_row_by_account( config::system_account_name, config::system_account_name, "rexfund"_n, act );
       return data.empty() ? asset(0, symbol{CORE_SYM}) : abi_ser.binary_to_variant("rex_fund", data, abi_serializer::create_yield_function(abi_serializer_max_time))["balance"].as<asset>();
    }
 
    fc::variant get_rex_fund_obj( const account_name& act ) const {
-      vector<char> data = get_row_by_account( config::system_account_name, config::system_account_name, N(rexfund), act );
+      vector<char> data = get_row_by_account( config::system_account_name, config::system_account_name, "rexfund"_n, act );
       return data.empty() ? fc::variant() : abi_ser.binary_to_variant( "rex_fund", data, abi_serializer::create_yield_function(abi_serializer_max_time) );
    }
 
    asset get_rex_vote_stake( const account_name& act ) const {
-      vector<char> data = get_row_by_account( config::system_account_name, config::system_account_name, N(rexbal), act );
+      vector<char> data = get_row_by_account( config::system_account_name, config::system_account_name, "rexbal"_n, act );
       return data.empty() ? core_sym::from_string("0.0000") : abi_ser.binary_to_variant("rex_balance", data, abi_serializer::create_yield_function(abi_serializer_max_time))["vote_stake"].as<asset>();
    }
 
    fc::variant get_rex_order( const account_name& act ) {
-      vector<char> data = get_row_by_account( config::system_account_name, config::system_account_name, N(rexqueue), act );
+      vector<char> data = get_row_by_account( config::system_account_name, config::system_account_name, "rexqueue"_n, act );
       return abi_ser.binary_to_variant( "rex_order", data, abi_serializer::create_yield_function(abi_serializer_max_time) );
    }
 
    fc::variant get_rex_order_obj( const account_name& act ) {
-      vector<char> data = get_row_by_account( config::system_account_name, config::system_account_name, N(rexqueue), act );
+      vector<char> data = get_row_by_account( config::system_account_name, config::system_account_name, "rexqueue"_n, act );
       return data.empty() ? fc::variant() : abi_ser.binary_to_variant( "rex_order", data, abi_serializer::create_yield_function(abi_serializer_max_time) );
    }
 
@@ -649,7 +649,7 @@ public:
       vector<char> data;
       const auto& db = control->db();
       namespace chain = eosio::chain;
-      const auto* t_id = db.find<eosio::chain::table_id_object, chain::by_code_scope_table>( boost::make_tuple( config::system_account_name, config::system_account_name, N(rexpool) ) );
+      const auto* t_id = db.find<eosio::chain::table_id_object, chain::by_code_scope_table>( boost::make_tuple( config::system_account_name, config::system_account_name, "rexpool"_n ) );
       if ( !t_id ) {
          return fc::variant();
       }
@@ -670,7 +670,7 @@ public:
       vector<char> data;
       const auto& db = control->db();
       namespace chain = eosio::chain;
-      const auto* t_id = db.find<eosio::chain::table_id_object, chain::by_code_scope_table>( boost::make_tuple( config::system_account_name, config::system_account_name, N(rexretpool) ) );
+      const auto* t_id = db.find<eosio::chain::table_id_object, chain::by_code_scope_table>( boost::make_tuple( config::system_account_name, config::system_account_name, "rexretpool"_n ) );
       if ( !t_id ) {
          return fc::variant();
       }
@@ -691,7 +691,7 @@ public:
       vector<char> data;
       const auto& db = control->db();
       namespace chain = eosio::chain;
-      const auto* t_id = db.find<eosio::chain::table_id_object, chain::by_code_scope_table>( boost::make_tuple( config::system_account_name, config::system_account_name, N(retbuckets) ) );
+      const auto* t_id = db.find<eosio::chain::table_id_object, chain::by_code_scope_table>( boost::make_tuple( config::system_account_name, config::system_account_name, "retbuckets"_n ) );
       if ( !t_id ) {
          return fc::variant();
       }
@@ -715,13 +715,13 @@ public:
                             bool deposit_into_rex_fund = true ) {
       const asset nstake = core_sym::from_string("10.0000");
       const asset cstake = core_sym::from_string("10.0000");
-      create_account_with_resources( N(proxyaccount), config::system_account_name, core_sym::from_string("1.0000"), false, net, cpu );
-      BOOST_REQUIRE_EQUAL( success(), push_action( N(proxyaccount), N(regproxy), mvo()("proxy", "proxyaccount")("isproxy", true) ) );
+      create_account_with_resources( "proxyaccount"_n, config::system_account_name, core_sym::from_string("1.0000"), false, net, cpu );
+      BOOST_REQUIRE_EQUAL( success(), push_action( "proxyaccount"_n, "regproxy"_n, mvo()("proxy", "proxyaccount")("isproxy", true) ) );
       for (const auto& a: accounts) {
          create_account_with_resources( a, config::system_account_name, core_sym::from_string("1.0000"), false, net, cpu );
          transfer( config::system_account_name, a, init_balance + nstake + cstake, config::system_account_name );
          BOOST_REQUIRE_EQUAL( success(),                        stake( a, a, nstake, cstake) );
-         BOOST_REQUIRE_EQUAL( success(),                        vote( a, { }, N(proxyaccount) ) );
+         BOOST_REQUIRE_EQUAL( success(),                        vote( a, { }, "proxyaccount"_n ) );
          BOOST_REQUIRE_EQUAL( init_balance,                     get_balance(a) );
          BOOST_REQUIRE_EQUAL( asset::from_string("0.0000 REX"), get_rex_balance(a) );
          if (deposit_into_rex_fund) {
@@ -733,7 +733,7 @@ public:
    }
 
    action_result bidname( const account_name& bidder, const account_name& newname, const asset& bid ) {
-      return push_action( name(bidder), N(bidname), mvo()
+      return push_action( name(bidder), "bidname"_n, mvo()
                           ("bidder",  bidder)
                           ("newname", newname)
                           ("bid", bid)
@@ -767,7 +767,7 @@ public:
    }
 
    action_result regproducer( const account_name& acnt, int params_fixture = 1 ) {
-      action_result r = push_action( acnt, N(regproducer), mvo()
+      action_result r = push_action( acnt, "regproducer"_n, mvo()
                           ("producer",  acnt )
                           ("producer_key", get_public_key( acnt, "active" ) )
                           ("url", "" )
@@ -778,7 +778,7 @@ public:
    }
 
    action_result vote( const account_name& voter, const std::vector<account_name>& producers, const account_name& proxy = name(0) ) {
-      return push_action(voter, N(voteproducer), mvo()
+      return push_action(voter, "voteproducer"_n, mvo()
                          ("voter",     voter)
                          ("proxy",     proxy)
                          ("producers", producers));
@@ -792,7 +792,7 @@ public:
    }
 
    asset get_balance( const account_name& act, symbol balance_symbol = symbol{CORE_SYM} ) {
-      vector<char> data = get_row_by_account( N(eosio.token), act, N(accounts), account_name(balance_symbol.to_symbol_code().value) );
+      vector<char> data = get_row_by_account( "eosio.token"_n, act, "accounts"_n, account_name(balance_symbol.to_symbol_code().value) );
       return data.empty() ? asset(0, balance_symbol) : token_abi_ser.binary_to_variant("account", data, abi_serializer::create_yield_function(abi_serializer_max_time))["balance"].as<asset>();
    }
 
@@ -801,7 +801,7 @@ public:
    }
 
    fc::variant get_total_stake( const account_name& act ) {
-      vector<char> data = get_row_by_account( config::system_account_name, act, N(userres), act );
+      vector<char> data = get_row_by_account( config::system_account_name, act, "userres"_n, act );
       return data.empty() ? fc::variant() : abi_ser.binary_to_variant( "user_resources", data, abi_serializer::create_yield_function(abi_serializer_max_time) );
    }
    fc::variant get_total_stake(  std::string_view act ) {
@@ -809,7 +809,7 @@ public:
    }
 
    fc::variant get_voter_info( const account_name& act ) {
-      vector<char> data = get_row_by_account( config::system_account_name, config::system_account_name, N(voters), act );
+      vector<char> data = get_row_by_account( config::system_account_name, config::system_account_name, "voters"_n, act );
       return data.empty() ? fc::variant() : abi_ser.binary_to_variant( "voter_info", data, abi_serializer::create_yield_function(abi_serializer_max_time) );
    }
    fc::variant get_voter_info(  std::string_view act ) {
@@ -817,7 +817,7 @@ public:
    }
 
    fc::variant get_producer_info( const account_name& act ) {
-      vector<char> data = get_row_by_account( config::system_account_name, config::system_account_name, N(producers), act );
+      vector<char> data = get_row_by_account( config::system_account_name, config::system_account_name, "producers"_n, act );
       return abi_ser.binary_to_variant( "producer_info", data, abi_serializer::create_yield_function(abi_serializer_max_time) );
    }
    fc::variant get_producer_info( std::string_view act ) {
@@ -825,7 +825,7 @@ public:
    }
 
    fc::variant get_producer_info2( const account_name& act ) {
-      vector<char> data = get_row_by_account( config::system_account_name, config::system_account_name, N(producers2), act );
+      vector<char> data = get_row_by_account( config::system_account_name, config::system_account_name, "producers2"_n, act );
       return abi_ser.binary_to_variant( "producer_info2", data, abi_serializer::create_yield_function(abi_serializer_max_time) );
    }
    fc::variant get_producer_info2( std::string_view act ) {
@@ -837,11 +837,11 @@ public:
          ("issuer",       manager )
          ("maximum_supply", maxsupply );
 
-      base_tester::push_action(contract, N(create), contract, act );
+      base_tester::push_action(contract, "create"_n, contract, act );
    }
 
    void issue( const asset& amount, const name& manager = config::system_account_name ) {
-      base_tester::push_action( N(eosio.token), N(issue), manager, mutable_variant_object()
+      base_tester::push_action( "eosio.token"_n, "issue"_n, manager, mutable_variant_object()
                                 ("to",       manager )
                                 ("quantity", amount )
                                 ("memo",     "")
@@ -849,7 +849,7 @@ public:
    }
 
    void transfer( const name& from, const name& to, const asset& amount, const name& manager = config::system_account_name ) {
-      base_tester::push_action( N(eosio.token), N(transfer), manager, mutable_variant_object()
+      base_tester::push_action( "eosio.token"_n, "transfer"_n, manager, mutable_variant_object()
                                 ("from",    from)
                                 ("to",      to )
                                 ("quantity", amount)
@@ -871,7 +871,7 @@ public:
 
    void issue_and_transfer( const name& to, const asset& amount, const name& manager = config::system_account_name ) {
       signed_transaction trx;
-      trx.actions.emplace_back( get_action( N(eosio.token), N(issue),
+      trx.actions.emplace_back( get_action( "eosio.token"_n, "issue"_n,
                                             vector<permission_level>{{manager, config::active_name}},
                                             mutable_variant_object()
                                             ("to",       manager )
@@ -880,7 +880,7 @@ public:
                                             )
                                 );
       if ( to != manager ) {
-         trx.actions.emplace_back( get_action( N(eosio.token), N(transfer),
+         trx.actions.emplace_back( get_action( "eosio.token"_n, "transfer"_n,
                                                vector<permission_level>{{manager, config::active_name}},
                                                mutable_variant_object()
                                                ("from",     manager)
@@ -919,7 +919,7 @@ public:
    fc::variant get_stats( const string& symbolname ) {
       auto symb = eosio::chain::symbol::from_string(symbolname);
       auto symbol_code = symb.to_symbol_code().value;
-      vector<char> data = get_row_by_account( N(eosio.token), name(symbol_code), N(stat), account_name(symbol_code) );
+      vector<char> data = get_row_by_account( "eosio.token"_n, name(symbol_code), "stat"_n, account_name(symbol_code) );
       return data.empty() ? fc::variant() : token_abi_ser.binary_to_variant( "currency_stats", data, abi_serializer::create_yield_function(abi_serializer_max_time) );
    }
 
@@ -932,44 +932,44 @@ public:
    }
 
    fc::variant get_global_state() {
-      vector<char> data = get_row_by_account( config::system_account_name, config::system_account_name, N(global), N(global) );
+      vector<char> data = get_row_by_account( config::system_account_name, config::system_account_name, "global"_n, "global"_n );
       if (data.empty()) std::cout << "\nData is empty\n" << std::endl;
       return data.empty() ? fc::variant() : abi_ser.binary_to_variant( "eosio_global_state", data, abi_serializer::create_yield_function(abi_serializer_max_time) );
    }
 
    fc::variant get_global_state2() {
-      vector<char> data = get_row_by_account( config::system_account_name, config::system_account_name, N(global2), N(global2) );
+      vector<char> data = get_row_by_account( config::system_account_name, config::system_account_name, "global2"_n, "global2"_n );
       return data.empty() ? fc::variant() : abi_ser.binary_to_variant( "eosio_global_state2", data, abi_serializer::create_yield_function(abi_serializer_max_time) );
    }
 
    fc::variant get_global_state3() {
-      vector<char> data = get_row_by_account( config::system_account_name, config::system_account_name, N(global3), N(global3) );
+      vector<char> data = get_row_by_account( config::system_account_name, config::system_account_name, "global3"_n, "global3"_n );
       return data.empty() ? fc::variant() : abi_ser.binary_to_variant( "eosio_global_state3", data, abi_serializer::create_yield_function(abi_serializer_max_time) );
    }
 
    fc::variant get_refund_request( name account ) {
-      vector<char> data = get_row_by_account( config::system_account_name, account, N(refunds), account );
+      vector<char> data = get_row_by_account( config::system_account_name, account, "refunds"_n, account );
       return data.empty() ? fc::variant() : abi_ser.binary_to_variant( "refund_request", data, abi_serializer::create_yield_function(abi_serializer_max_time) );
    }
 
    abi_serializer initialize_multisig() {
       abi_serializer msig_abi_ser;
       {
-         create_account_with_resources( N(eosio.msig), config::system_account_name );
-         BOOST_REQUIRE_EQUAL( success(), buyram( N(eosio), N(eosio.msig), core_sym::from_string("5000.0000") ) );
+         create_account_with_resources( "eosio.msig"_n, config::system_account_name );
+         BOOST_REQUIRE_EQUAL( success(), buyram( "eosio"_n, "eosio.msig"_n, core_sym::from_string("5000.0000") ) );
          produce_block();
 
-         auto trace = base_tester::push_action(config::system_account_name, N(setpriv),
+         auto trace = base_tester::push_action(config::system_account_name, "setpriv"_n,
                                                config::system_account_name,  mutable_variant_object()
                                                ("account", "eosio.msig")
                                                ("is_priv", 1)
          );
 
-         set_code( N(eosio.msig), contracts::msig_wasm() );
-         set_abi( N(eosio.msig), contracts::msig_abi().data() );
+         set_code( "eosio.msig"_n, contracts::msig_wasm() );
+         set_abi( "eosio.msig"_n, contracts::msig_abi().data() );
 
          produce_blocks();
-         const auto& accnt = control->db().get<account_object,by_name>( N(eosio.msig) );
+         const auto& accnt = control->db().get<account_object,by_name>( "eosio.msig"_n );
          abi_def msig_abi;
          BOOST_REQUIRE_EQUAL(abi_serializer::to_abi(accnt.abi, msig_abi), true);
          msig_abi_ser.set_abi(msig_abi, abi_serializer::create_yield_function(abi_serializer_max_time));
@@ -979,8 +979,8 @@ public:
 
    vector<name> active_and_vote_producers() {
       //stake more than 15% of total EOS supply to activate chain
-      transfer( N(eosio), N(alice1111111), core_sym::from_string("650000000.0000"), config::system_account_name );
-      BOOST_REQUIRE_EQUAL( success(), stake( N(alice1111111), N(alice1111111), core_sym::from_string("300000000.0000"), core_sym::from_string("300000000.0000") ) );
+      transfer( "eosio"_n, "alice1111111"_n, core_sym::from_string("650000000.0000"), config::system_account_name );
+      BOOST_REQUIRE_EQUAL( success(), stake( "alice1111111"_n, "alice1111111"_n, core_sym::from_string("300000000.0000"), core_sym::from_string("300000000.0000") ) );
 
       // create accounts {defproducera, defproducerb, ..., defproducerz} and register as producers
       std::vector<account_name> producer_names;
@@ -1012,10 +1012,10 @@ public:
 
       //vote for producers
       {
-         transfer( config::system_account_name, N(alice1111111), core_sym::from_string("100000000.0000"), config::system_account_name );
-         BOOST_REQUIRE_EQUAL(success(), stake( N(alice1111111), core_sym::from_string("30000000.0000"), core_sym::from_string("30000000.0000") ) );
-         BOOST_REQUIRE_EQUAL(success(), buyram( N(alice1111111), N(alice1111111), core_sym::from_string("30000000.0000") ) );
-         BOOST_REQUIRE_EQUAL(success(), push_action(N(alice1111111), N(voteproducer), mvo()
+         transfer( config::system_account_name, "alice1111111"_n, core_sym::from_string("100000000.0000"), config::system_account_name );
+         BOOST_REQUIRE_EQUAL(success(), stake( "alice1111111"_n, core_sym::from_string("30000000.0000"), core_sym::from_string("30000000.0000") ) );
+         BOOST_REQUIRE_EQUAL(success(), buyram( "alice1111111"_n, "alice1111111"_n, core_sym::from_string("30000000.0000") ) );
+         BOOST_REQUIRE_EQUAL(success(), push_action("alice1111111"_n, "voteproducer"_n, mvo()
                                                     ("voter",  "alice1111111")
                                                     ("proxy", name(0).to_string())
                                                     ("producers", vector<account_name>(producer_names.begin(), producer_names.begin()+21))
@@ -1032,13 +1032,13 @@ public:
    }
 
    void cross_15_percent_threshold() {
-      setup_producer_accounts({N(producer1111)});
-      regproducer(N(producer1111));
+      setup_producer_accounts({"producer1111"_n});
+      regproducer("producer1111"_n);
       {
          signed_transaction trx;
          set_transaction_headers(trx);
 
-         trx.actions.emplace_back( get_action( config::system_account_name, N(delegatebw),
+         trx.actions.emplace_back( get_action( config::system_account_name, "delegatebw"_n,
                                                vector<permission_level>{{config::system_account_name, config::active_name}},
                                                mvo()
                                                ("from", name{config::system_account_name})
@@ -1048,16 +1048,16 @@ public:
                                                ("transfer", 1 )
                                              )
                                  );
-         trx.actions.emplace_back( get_action( config::system_account_name, N(voteproducer),
-                                               vector<permission_level>{{N(producer1111), config::active_name}},
+         trx.actions.emplace_back( get_action( config::system_account_name, "voteproducer"_n,
+                                               vector<permission_level>{{"producer1111"_n, config::active_name}},
                                                mvo()
                                                ("voter", "producer1111")
                                                ("proxy", name(0).to_string())
-                                               ("producers", vector<account_name>(1, N(producer1111)))
+                                               ("producers", vector<account_name>(1, "producer1111"_n))
                                              )
                                  );
-         trx.actions.emplace_back( get_action( config::system_account_name, N(undelegatebw),
-                                               vector<permission_level>{{N(producer1111), config::active_name}},
+         trx.actions.emplace_back( get_action( config::system_account_name, "undelegatebw"_n,
+                                               vector<permission_level>{{"producer1111"_n, config::active_name}},
                                                mvo()
                                                ("from", "producer1111")
                                                ("receiver", "producer1111")
@@ -1068,14 +1068,14 @@ public:
 
          set_transaction_headers(trx);
          trx.sign( get_private_key( config::system_account_name, "active" ), control->get_chain_id()  );
-         trx.sign( get_private_key( N(producer1111), "active" ), control->get_chain_id()  );
+         trx.sign( get_private_key( "producer1111"_n, "active" ), control->get_chain_id()  );
          push_transaction( trx );
          produce_block();
       }
    }
 
    action_result setinflation( int64_t annual_rate, int64_t inflation_pay_factor, int64_t votepay_factor ) {
-      return push_action( N(eosio), N(setinflation), mvo()
+      return push_action( "eosio"_n, "setinflation"_n, mvo()
                ("annual_rate",     annual_rate)
                ("inflation_pay_factor", inflation_pay_factor)
                ("votepay_factor", votepay_factor)

--- a/tests/eosio.system_tests.cpp
+++ b/tests/eosio.system_tests.cpp
@@ -40,12 +40,12 @@ BOOST_FIXTURE_TEST_CASE( buysell, eosio_system_tester ) try {
    auto total = get_total_stake( "alice1111111" );
    auto init_bytes =  total["ram_bytes"].as_uint64();
 
-   const asset initial_ram_balance = get_balance(N(eosio.ram));
-   const asset initial_ramfee_balance = get_balance(N(eosio.ramfee));
+   const asset initial_ram_balance = get_balance("eosio.ram"_n);
+   const asset initial_ramfee_balance = get_balance("eosio.ramfee"_n);
    BOOST_REQUIRE_EQUAL( success(), buyram( "alice1111111", "alice1111111", core_sym::from_string("200.0000") ) );
    BOOST_REQUIRE_EQUAL( core_sym::from_string("800.0000"), get_balance( "alice1111111" ) );
-   BOOST_REQUIRE_EQUAL( initial_ram_balance + core_sym::from_string("199.0000"), get_balance(N(eosio.ram)) );
-   BOOST_REQUIRE_EQUAL( initial_ramfee_balance + core_sym::from_string("1.0000"), get_balance(N(eosio.ramfee)) );
+   BOOST_REQUIRE_EQUAL( initial_ram_balance + core_sym::from_string("199.0000"), get_balance("eosio.ram"_n) );
+   BOOST_REQUIRE_EQUAL( initial_ramfee_balance + core_sym::from_string("1.0000"), get_balance("eosio.ramfee"_n) );
 
    total = get_total_stake( "alice1111111" );
    auto bytes = total["ram_bytes"].as_uint64();
@@ -127,17 +127,17 @@ BOOST_FIXTURE_TEST_CASE( buysell, eosio_system_tester ) try {
    BOOST_REQUIRE_EQUAL( success(), sellram( "alice1111111", bought_bytes ) );
 
    BOOST_REQUIRE_EQUAL( false, get_row_by_account( config::system_account_name, config::system_account_name,
-                                                   N(rammarket), account_name(symbol{SY(4,RAMCORE)}.value()) ).empty() );
+                                                   "rammarket"_n, account_name(symbol{SY(4,RAMCORE)}.value()) ).empty() );
 
    auto get_ram_market = [this]() -> fc::variant {
       vector<char> data = get_row_by_account( config::system_account_name, config::system_account_name,
-                                              N(rammarket), account_name(symbol{SY(4,RAMCORE)}.value()) );
+                                              "rammarket"_n, account_name(symbol{SY(4,RAMCORE)}.value()) );
       BOOST_REQUIRE( !data.empty() );
       return abi_ser.binary_to_variant("exchange_state", data, abi_serializer::create_yield_function(abi_serializer_max_time));
    };
 
    {
-      transfer( config::system_account_name, N(alice1111111), core_sym::from_string("10000000.0000"), config::system_account_name );
+      transfer( config::system_account_name, "alice1111111"_n, core_sym::from_string("10000000.0000"), config::system_account_name );
       uint64_t bytes0 = get_total_stake( "alice1111111" )["ram_bytes"].as_uint64();
 
       auto market = get_ram_market();
@@ -158,7 +158,7 @@ BOOST_FIXTURE_TEST_CASE( buysell, eosio_system_tester ) try {
    }
 
    {
-      transfer( config::system_account_name, N(bob111111111), core_sym::from_string("100000.0000"), config::system_account_name );
+      transfer( config::system_account_name, "bob111111111"_n, core_sym::from_string("100000.0000"), config::system_account_name );
       BOOST_REQUIRE_EQUAL( wasm_assert_msg("must reserve a positive amount"),
                            buyrambytes( "bob111111111", "bob111111111", 1 ) );
 
@@ -190,22 +190,22 @@ BOOST_FIXTURE_TEST_CASE( stake_unstake, eosio_system_tester ) try {
    BOOST_REQUIRE_EQUAL( core_sym::from_string("210.0000"), total["net_weight"].as<asset>());
    BOOST_REQUIRE_EQUAL( core_sym::from_string("110.0000"), total["cpu_weight"].as<asset>());
 
-   const auto init_eosio_stake_balance = get_balance( N(eosio.stake) );
+   const auto init_eosio_stake_balance = get_balance( "eosio.stake"_n );
    BOOST_REQUIRE_EQUAL( success(), stake( "alice1111111", "alice1111111", core_sym::from_string("200.0000"), core_sym::from_string("100.0000") ) );
    BOOST_REQUIRE_EQUAL( core_sym::from_string("700.0000"), get_balance( "alice1111111" ) );
-   BOOST_REQUIRE_EQUAL( init_eosio_stake_balance + core_sym::from_string("300.0000"), get_balance( N(eosio.stake) ) );
+   BOOST_REQUIRE_EQUAL( init_eosio_stake_balance + core_sym::from_string("300.0000"), get_balance( "eosio.stake"_n ) );
    BOOST_REQUIRE_EQUAL( success(), unstake( "alice1111111", "alice1111111", core_sym::from_string("200.0000"), core_sym::from_string("100.0000") ) );
    BOOST_REQUIRE_EQUAL( core_sym::from_string("700.0000"), get_balance( "alice1111111" ) );
 
    produce_block( fc::hours(3*24-1) );
    produce_blocks(1);
    BOOST_REQUIRE_EQUAL( core_sym::from_string("700.0000"), get_balance( "alice1111111" ) );
-   BOOST_REQUIRE_EQUAL( init_eosio_stake_balance + core_sym::from_string("300.0000"), get_balance( N(eosio.stake) ) );
+   BOOST_REQUIRE_EQUAL( init_eosio_stake_balance + core_sym::from_string("300.0000"), get_balance( "eosio.stake"_n ) );
    //after 3 days funds should be released
    produce_block( fc::hours(1) );
    produce_blocks(1);
    BOOST_REQUIRE_EQUAL( core_sym::from_string("1000.0000"), get_balance( "alice1111111" ) );
-   BOOST_REQUIRE_EQUAL( init_eosio_stake_balance, get_balance( N(eosio.stake) ) );
+   BOOST_REQUIRE_EQUAL( init_eosio_stake_balance, get_balance( "eosio.stake"_n ) );
 
    BOOST_REQUIRE_EQUAL( success(), stake( "alice1111111", "bob111111111", core_sym::from_string("200.0000"), core_sym::from_string("100.0000") ) );
    BOOST_REQUIRE_EQUAL( core_sym::from_string("700.0000"), get_balance( "alice1111111" ) );
@@ -247,7 +247,7 @@ BOOST_FIXTURE_TEST_CASE( stake_unstake_with_transfer, eosio_system_tester ) try 
    //eosio stakes for alice with transfer flag
 
    transfer( "eosio", "bob111111111", core_sym::from_string("1000.0000"), "eosio" );
-   BOOST_REQUIRE_EQUAL( success(), stake_with_transfer( N(bob111111111), N(alice1111111), core_sym::from_string("200.0000"), core_sym::from_string("100.0000") ) );
+   BOOST_REQUIRE_EQUAL( success(), stake_with_transfer( "bob111111111"_n, "alice1111111"_n, core_sym::from_string("200.0000"), core_sym::from_string("100.0000") ) );
 
    //check that alice has both bandwidth and voting power
    auto total = get_total_stake("alice1111111");
@@ -288,7 +288,7 @@ BOOST_FIXTURE_TEST_CASE( stake_unstake_with_transfer, eosio_system_tester ) try 
    REQUIRE_MATCHING_OBJECT( voter( "alice1111111", core_sym::from_string("0.0000")), get_voter_info( "alice1111111" ) );
 
    // Now alice stakes to bob with transfer flag
-   BOOST_REQUIRE_EQUAL( success(), stake_with_transfer( N(alice1111111), N(bob111111111), core_sym::from_string("100.0000"), core_sym::from_string("100.0000") ) );
+   BOOST_REQUIRE_EQUAL( success(), stake_with_transfer( "alice1111111"_n, "bob111111111"_n, core_sym::from_string("100.0000"), core_sym::from_string("100.0000") ) );
 
 } FC_LOG_AND_RETHROW()
 
@@ -299,7 +299,7 @@ BOOST_FIXTURE_TEST_CASE( stake_to_self_with_transfer, eosio_system_tester ) try 
    transfer( "eosio", "alice1111111", core_sym::from_string("1000.0000"), "eosio" );
 
    BOOST_REQUIRE_EQUAL( wasm_assert_msg("cannot use transfer flag if delegating to self"),
-                        stake_with_transfer( N(alice1111111), N(alice1111111), core_sym::from_string("200.0000"), core_sym::from_string("100.0000") )
+                        stake_with_transfer( "alice1111111"_n, "alice1111111"_n, core_sym::from_string("200.0000"), core_sym::from_string("100.0000") )
    );
 
 } FC_LOG_AND_RETHROW()
@@ -311,7 +311,7 @@ BOOST_FIXTURE_TEST_CASE( stake_while_pending_refund, eosio_system_tester ) try {
 
    //eosio stakes for alice with transfer flag
    transfer( "eosio", "bob111111111", core_sym::from_string("1000.0000"), "eosio" );
-   BOOST_REQUIRE_EQUAL( success(), stake_with_transfer( N(bob111111111), N(alice1111111), core_sym::from_string("200.0000"), core_sym::from_string("100.0000") ) );
+   BOOST_REQUIRE_EQUAL( success(), stake_with_transfer( "bob111111111"_n, "alice1111111"_n, core_sym::from_string("200.0000"), core_sym::from_string("100.0000") ) );
 
    //check that alice has both bandwidth and voting power
    auto total = get_total_stake("alice1111111");
@@ -352,7 +352,7 @@ BOOST_FIXTURE_TEST_CASE( stake_while_pending_refund, eosio_system_tester ) try {
    REQUIRE_MATCHING_OBJECT( voter( "alice1111111", core_sym::from_string("0.0000")), get_voter_info( "alice1111111" ) );
 
    // Now alice stakes to bob with transfer flag
-   BOOST_REQUIRE_EQUAL( success(), stake_with_transfer( N(alice1111111), N(bob111111111), core_sym::from_string("100.0000"), core_sym::from_string("100.0000") ) );
+   BOOST_REQUIRE_EQUAL( success(), stake_with_transfer( "alice1111111"_n, "bob111111111"_n, core_sym::from_string("100.0000"), core_sym::from_string("100.0000") ) );
 
 } FC_LOG_AND_RETHROW()
 
@@ -365,7 +365,7 @@ BOOST_FIXTURE_TEST_CASE( fail_without_auth, eosio_system_tester ) try {
    BOOST_REQUIRE_EQUAL( success(), stake( "alice1111111", "bob111111111", core_sym::from_string("10.0000"), core_sym::from_string("10.0000") ) );
 
    BOOST_REQUIRE_EQUAL( error("missing authority of alice1111111"),
-                        push_action( N(alice1111111), N(delegatebw), mvo()
+                        push_action( "alice1111111"_n, "delegatebw"_n, mvo()
                                     ("from",     "alice1111111")
                                     ("receiver", "bob111111111")
                                     ("stake_net_quantity", core_sym::from_string("10.0000"))
@@ -376,7 +376,7 @@ BOOST_FIXTURE_TEST_CASE( fail_without_auth, eosio_system_tester ) try {
    );
 
    BOOST_REQUIRE_EQUAL( error("missing authority of alice1111111"),
-                        push_action(N(alice1111111), N(undelegatebw), mvo()
+                        push_action("alice1111111"_n, "undelegatebw"_n, mvo()
                                     ("from",     "alice1111111")
                                     ("receiver", "bob111111111")
                                     ("unstake_net_quantity", core_sym::from_string("200.0000"))
@@ -635,7 +635,7 @@ BOOST_FIXTURE_TEST_CASE( stake_from_refund, eosio_system_tester ) try {
    BOOST_REQUIRE_EQUAL( core_sym::from_string("60.0000"), total["cpu_weight"].as<asset>());
    REQUIRE_MATCHING_OBJECT( voter( "alice1111111", core_sym::from_string("250.0000") ), get_voter_info( "alice1111111" ) );
    BOOST_REQUIRE_EQUAL( core_sym::from_string("600.0000"), get_balance( "alice1111111" ) );
-   auto refund = get_refund_request( N(alice1111111) );
+   auto refund = get_refund_request( "alice1111111"_n );
    BOOST_REQUIRE_EQUAL( core_sym::from_string("100.0000"), refund["net_amount"].as<asset>() );
    BOOST_REQUIRE_EQUAL( core_sym::from_string( "50.0000"), refund["cpu_amount"].as<asset>() );
    //XXX auto request_time = refund["request_time"].as_int64();
@@ -647,7 +647,7 @@ BOOST_FIXTURE_TEST_CASE( stake_from_refund, eosio_system_tester ) try {
    BOOST_REQUIRE_EQUAL( core_sym::from_string("60.0000"), total["cpu_weight"].as<asset>());
    REQUIRE_MATCHING_OBJECT( voter( "alice1111111", core_sym::from_string("350.0000") ), get_voter_info( "alice1111111" ) );
    BOOST_REQUIRE_EQUAL( core_sym::from_string("500.0000"), get_balance( "alice1111111" ) );
-   refund = get_refund_request( N(alice1111111) );
+   refund = get_refund_request( "alice1111111"_n );
    BOOST_REQUIRE_EQUAL( core_sym::from_string("100.0000"), refund["net_amount"].as<asset>() );
    BOOST_REQUIRE_EQUAL( core_sym::from_string( "50.0000"), refund["cpu_amount"].as<asset>() );
 
@@ -656,7 +656,7 @@ BOOST_FIXTURE_TEST_CASE( stake_from_refund, eosio_system_tester ) try {
    total = get_total_stake( "alice1111111" );
    BOOST_REQUIRE_EQUAL( core_sym::from_string("160.0000"), total["net_weight"].as<asset>());
    BOOST_REQUIRE_EQUAL( core_sym::from_string("85.0000"), total["cpu_weight"].as<asset>());
-   refund = get_refund_request( N(alice1111111) );
+   refund = get_refund_request( "alice1111111"_n );
    BOOST_REQUIRE_EQUAL( core_sym::from_string("50.0000"), refund["net_amount"].as<asset>() );
    BOOST_REQUIRE_EQUAL( core_sym::from_string("25.0000"), refund["cpu_amount"].as<asset>() );
    //request time should stay the same
@@ -670,7 +670,7 @@ BOOST_FIXTURE_TEST_CASE( stake_from_refund, eosio_system_tester ) try {
    BOOST_REQUIRE_EQUAL( core_sym::from_string("210.0000"), total["net_weight"].as<asset>());
    BOOST_REQUIRE_EQUAL( core_sym::from_string("110.0000"), total["cpu_weight"].as<asset>());
    //pending refund should be removed
-   refund = get_refund_request( N(alice1111111) );
+   refund = get_refund_request( "alice1111111"_n );
    BOOST_TEST_REQUIRE( refund.is_null() );
    //balance should stay the same
    BOOST_REQUIRE_EQUAL( core_sym::from_string("500.0000"), get_balance( "alice1111111" ) );
@@ -681,7 +681,7 @@ BOOST_FIXTURE_TEST_CASE( stake_from_refund, eosio_system_tester ) try {
    BOOST_REQUIRE_EQUAL( core_sym::from_string("10.0000"), total["net_weight"].as<asset>());
    BOOST_REQUIRE_EQUAL( core_sym::from_string("10.0000"), total["cpu_weight"].as<asset>());
    BOOST_REQUIRE_EQUAL( core_sym::from_string("500.0000"), get_balance( "alice1111111" ) );
-   refund = get_refund_request( N(alice1111111) );
+   refund = get_refund_request( "alice1111111"_n );
    BOOST_REQUIRE_EQUAL( core_sym::from_string("200.0000"), refund["net_amount"].as<asset>() );
    BOOST_REQUIRE_EQUAL( core_sym::from_string("100.0000"), refund["cpu_amount"].as<asset>() );
 
@@ -691,7 +691,7 @@ BOOST_FIXTURE_TEST_CASE( stake_from_refund, eosio_system_tester ) try {
    BOOST_REQUIRE_EQUAL( core_sym::from_string("310.0000"), total["net_weight"].as<asset>());
    BOOST_REQUIRE_EQUAL( core_sym::from_string("210.0000"), total["cpu_weight"].as<asset>());
    REQUIRE_MATCHING_OBJECT( voter( "alice1111111", core_sym::from_string("700.0000") ), get_voter_info( "alice1111111" ) );
-   refund = get_refund_request( N(alice1111111) );
+   refund = get_refund_request( "alice1111111"_n );
    BOOST_TEST_REQUIRE( refund.is_null() );
    //200 core tokens should be taken from alice's account
    BOOST_REQUIRE_EQUAL( core_sym::from_string("300.0000"), get_balance( "alice1111111" ) );
@@ -714,7 +714,7 @@ BOOST_FIXTURE_TEST_CASE( stake_to_another_user_not_from_refund, eosio_system_tes
 
    //unstake
    BOOST_REQUIRE_EQUAL( success(), unstake( "alice1111111", core_sym::from_string("200.0000"), core_sym::from_string("100.0000") ) );
-   auto refund = get_refund_request( N(alice1111111) );
+   auto refund = get_refund_request( "alice1111111"_n );
    BOOST_REQUIRE_EQUAL( core_sym::from_string("200.0000"), refund["net_amount"].as<asset>() );
    BOOST_REQUIRE_EQUAL( core_sym::from_string("100.0000"), refund["cpu_amount"].as<asset>() );
    //auto orig_request_time = refund["request_time"].as_int64();
@@ -726,7 +726,7 @@ BOOST_FIXTURE_TEST_CASE( stake_to_another_user_not_from_refund, eosio_system_tes
    BOOST_REQUIRE_EQUAL( core_sym::from_string("110.0000"), total["cpu_weight"].as<asset>());
    //stake should be taken from alices' balance, and refund request should stay the same
    BOOST_REQUIRE_EQUAL( core_sym::from_string("400.0000"), get_balance( "alice1111111" ) );
-   refund = get_refund_request( N(alice1111111) );
+   refund = get_refund_request( "alice1111111"_n );
    BOOST_REQUIRE_EQUAL( core_sym::from_string("200.0000"), refund["net_amount"].as<asset>() );
    BOOST_REQUIRE_EQUAL( core_sym::from_string("100.0000"), refund["cpu_amount"].as<asset>() );
    //BOOST_REQUIRE_EQUAL( orig_request_time, refund["request_time"].as_int64() );
@@ -739,7 +739,7 @@ BOOST_FIXTURE_TEST_CASE( producer_register_unregister, eosio_system_tester ) try
 
    //fc::variant params = producer_parameters_example(1);
    auto key =  fc::crypto::public_key( std::string("EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV") );
-   BOOST_REQUIRE_EQUAL( success(), push_action(N(alice1111111), N(regproducer), mvo()
+   BOOST_REQUIRE_EQUAL( success(), push_action("alice1111111"_n, "regproducer"_n, mvo()
                                                ("producer",  "alice1111111")
                                                ("producer_key", key )
                                                ("url", "http://block.one")
@@ -754,7 +754,7 @@ BOOST_FIXTURE_TEST_CASE( producer_register_unregister, eosio_system_tester ) try
 
    //change parameters one by one to check for things like #3783
    //fc::variant params2 = producer_parameters_example(2);
-   BOOST_REQUIRE_EQUAL( success(), push_action(N(alice1111111), N(regproducer), mvo()
+   BOOST_REQUIRE_EQUAL( success(), push_action("alice1111111"_n, "regproducer"_n, mvo()
                                                ("producer",  "alice1111111")
                                                ("producer_key", key )
                                                ("url", "http://block.two")
@@ -768,7 +768,7 @@ BOOST_FIXTURE_TEST_CASE( producer_register_unregister, eosio_system_tester ) try
    BOOST_REQUIRE_EQUAL( 1, info["location"].as_int64() );
 
    auto key2 =  fc::crypto::public_key( std::string("EOS5jnmSKrzdBHE9n8hw58y7yxFWBC8SNiG7m8S1crJH3KvAnf9o6") );
-   BOOST_REQUIRE_EQUAL( success(), push_action(N(alice1111111), N(regproducer), mvo()
+   BOOST_REQUIRE_EQUAL( success(), push_action("alice1111111"_n, "regproducer"_n, mvo()
                                                ("producer",  "alice1111111")
                                                ("producer_key", key2 )
                                                ("url", "http://block.two")
@@ -782,7 +782,7 @@ BOOST_FIXTURE_TEST_CASE( producer_register_unregister, eosio_system_tester ) try
    BOOST_REQUIRE_EQUAL( 2, info["location"].as_int64() );
 
    //unregister producer
-   BOOST_REQUIRE_EQUAL( success(), push_action(N(alice1111111), N(unregprod), mvo()
+   BOOST_REQUIRE_EQUAL( success(), push_action("alice1111111"_n, "unregprod"_n, mvo()
                                                ("producer",  "alice1111111")
                         )
    );
@@ -796,7 +796,7 @@ BOOST_FIXTURE_TEST_CASE( producer_register_unregister, eosio_system_tester ) try
 
    //unregister bob111111111 who is not a producer
    BOOST_REQUIRE_EQUAL( wasm_assert_msg( "producer not found" ),
-                        push_action( N(bob111111111), N(unregprod), mvo()
+                        push_action( "bob111111111"_n, "unregprod"_n, mvo()
                                      ("producer",  "bob111111111")
                         )
    );
@@ -809,25 +809,25 @@ BOOST_FIXTURE_TEST_CASE( producer_wtmsig, eosio_system_tester ) try {
 
    BOOST_REQUIRE_EQUAL( control->active_producers().version, 0u );
 
-   issue_and_transfer( N(alice1111111), core_sym::from_string("200000000.0000"),  config::system_account_name );
+   issue_and_transfer( "alice1111111"_n, core_sym::from_string("200000000.0000"),  config::system_account_name );
    block_signing_authority_v0 alice_signing_authority;
    alice_signing_authority.threshold = 1;
-   alice_signing_authority.keys.push_back( {.key = get_public_key( N(alice1111111), "bs1"), .weight = 1} );
-   alice_signing_authority.keys.push_back( {.key = get_public_key( N(alice1111111), "bs2"), .weight = 1} );
-   producer_authority alice_producer_authority = {.producer_name = N(alice1111111), .authority = alice_signing_authority};
-   BOOST_REQUIRE_EQUAL( success(), push_action( N(alice1111111), N(regproducer2), mvo()
+   alice_signing_authority.keys.push_back( {.key = get_public_key( "alice1111111"_n, "bs1"), .weight = 1} );
+   alice_signing_authority.keys.push_back( {.key = get_public_key( "alice1111111"_n, "bs2"), .weight = 1} );
+   producer_authority alice_producer_authority = {.producer_name = "alice1111111"_n, .authority = alice_signing_authority};
+   BOOST_REQUIRE_EQUAL( success(), push_action( "alice1111111"_n, "regproducer2"_n, mvo()
                                                ("producer",  "alice1111111")
                                                ("producer_authority", alice_producer_authority.get_abi_variant()["authority"])
                                                ("url", "http://block.one")
                                                ("location", 0 )
                         )
    );
-   BOOST_REQUIRE_EQUAL( success(), stake( N(alice1111111), core_sym::from_string("100000000.0000"), core_sym::from_string("100000000.0000") ) );
-   BOOST_REQUIRE_EQUAL( success(), vote( N(alice1111111), { N(alice1111111) } ) );
+   BOOST_REQUIRE_EQUAL( success(), stake( "alice1111111"_n, core_sym::from_string("100000000.0000"), core_sym::from_string("100000000.0000") ) );
+   BOOST_REQUIRE_EQUAL( success(), vote( "alice1111111"_n, { "alice1111111"_n } ) );
 
-   block_signing_private_keys.emplace(get_public_key(N(alice1111111), "bs1"), get_private_key(N(alice1111111), "bs1"));
+   block_signing_private_keys.emplace(get_public_key("alice1111111"_n, "bs1"), get_private_key("alice1111111"_n, "bs1"));
 
-   auto alice_prod_info = get_producer_info( N(alice1111111) );
+   auto alice_prod_info = get_producer_info( "alice1111111"_n );
    wdump((alice_prod_info));
    BOOST_REQUIRE_EQUAL( alice_prod_info["is_active"], true );
 
@@ -836,7 +836,7 @@ BOOST_FIXTURE_TEST_CASE( producer_wtmsig, eosio_system_tester ) try {
    produce_blocks(2);
    BOOST_REQUIRE_EQUAL( control->active_producers().version, 1u );
    produce_block();
-   BOOST_REQUIRE_EQUAL( control->pending_block_producer(), N(alice1111111) );
+   BOOST_REQUIRE_EQUAL( control->pending_block_producer(), "alice1111111"_n );
    produce_block();
 
    alice_signing_authority.threshold = 0;
@@ -844,7 +844,7 @@ BOOST_FIXTURE_TEST_CASE( producer_wtmsig, eosio_system_tester ) try {
 
    // Ensure an authority with a threshold of 0 is rejected.
    BOOST_REQUIRE_EQUAL( error("assertion failure with message: invalid producer authority"),
-                        push_action( N(alice1111111), N(regproducer2), mvo()
+                        push_action( "alice1111111"_n, "regproducer2"_n, mvo()
                                        ("producer",  "alice1111111")
                                        ("producer_authority", alice_producer_authority.get_abi_variant()["authority"])
                                        ("url", "http://block.one")
@@ -856,7 +856,7 @@ BOOST_FIXTURE_TEST_CASE( producer_wtmsig, eosio_system_tester ) try {
    alice_signing_authority.threshold = 3;
    alice_producer_authority.authority = alice_signing_authority;
    BOOST_REQUIRE_EQUAL( error("assertion failure with message: invalid producer authority"),
-                        push_action( N(alice1111111), N(regproducer2), mvo()
+                        push_action( "alice1111111"_n, "regproducer2"_n, mvo()
                                        ("producer",  "alice1111111")
                                        ("producer_authority", alice_producer_authority.get_abi_variant()["authority"])
                                        ("url", "http://block.one")
@@ -869,7 +869,7 @@ BOOST_FIXTURE_TEST_CASE( producer_wtmsig, eosio_system_tester ) try {
    alice_signing_authority.keys[1] = alice_signing_authority.keys[0];
    alice_producer_authority.authority = alice_signing_authority;
    BOOST_REQUIRE_EQUAL( error("assertion failure with message: invalid producer authority"),
-                        push_action( N(alice1111111), N(regproducer2), mvo()
+                        push_action( "alice1111111"_n, "regproducer2"_n, mvo()
                                        ("producer",  "alice1111111")
                                        ("producer_authority", alice_producer_authority.get_abi_variant()["authority"])
                                        ("url", "http://block.one")
@@ -881,7 +881,7 @@ BOOST_FIXTURE_TEST_CASE( producer_wtmsig, eosio_system_tester ) try {
    alice_signing_authority.keys[1] = {};
    alice_producer_authority.authority = alice_signing_authority;
    BOOST_REQUIRE_EQUAL( success(),
-                        push_action( N(alice1111111), N(regproducer2), mvo()
+                        push_action( "alice1111111"_n, "regproducer2"_n, mvo()
                                        ("producer",  "alice1111111")
                                        ("producer_authority", alice_producer_authority.get_abi_variant()["authority"])
                                        ("url", "http://block.one")
@@ -894,7 +894,7 @@ BOOST_FIXTURE_TEST_CASE( producer_wtmsig, eosio_system_tester ) try {
    produce_blocks(2);
    BOOST_REQUIRE_EQUAL( control->active_producers().version, 2u );
    produce_block();
-   BOOST_REQUIRE_EQUAL( control->pending_block_producer(), N(alice1111111) );
+   BOOST_REQUIRE_EQUAL( control->pending_block_producer(), "alice1111111"_n );
    produce_block();
 
 } FC_LOG_AND_RETHROW()
@@ -907,18 +907,18 @@ BOOST_FIXTURE_TEST_CASE( producer_wtmsig_transition, eosio_system_tester ) try {
    set_code( config::system_account_name, contracts::util::system_wasm_v1_8() );
    set_abi(  config::system_account_name, contracts::util::system_abi_v1_8().data() );
 
-   issue_and_transfer( N(alice1111111), core_sym::from_string("200000000.0000"),  config::system_account_name );
-   BOOST_REQUIRE_EQUAL( success(), push_action( N(alice1111111), N(regproducer), mvo()
+   issue_and_transfer( "alice1111111"_n, core_sym::from_string("200000000.0000"),  config::system_account_name );
+   BOOST_REQUIRE_EQUAL( success(), push_action( "alice1111111"_n, "regproducer"_n, mvo()
                                                ("producer",  "alice1111111")
-                                               ("producer_key", get_public_key( N(alice1111111), "active") )
+                                               ("producer_key", get_public_key( "alice1111111"_n, "active") )
                                                ("url","")
                                                ("location", 0)
                         )
    );
-   BOOST_REQUIRE_EQUAL( success(), stake( N(alice1111111), core_sym::from_string("100000000.0000"), core_sym::from_string("100000000.0000") ) );
-   BOOST_REQUIRE_EQUAL( success(), vote( N(alice1111111), { N(alice1111111) } ) );
+   BOOST_REQUIRE_EQUAL( success(), stake( "alice1111111"_n, core_sym::from_string("100000000.0000"), core_sym::from_string("100000000.0000") ) );
+   BOOST_REQUIRE_EQUAL( success(), vote( "alice1111111"_n, { "alice1111111"_n } ) );
 
-   //auto alice_prod_info1 = get_producer_info( N(alice1111111) );
+   //auto alice_prod_info1 = get_producer_info( "alice1111111"_n );
    //wdump((alice_prod_info1));
 
    produce_block();
@@ -930,14 +930,14 @@ BOOST_FIXTURE_TEST_CASE( producer_wtmsig_transition, eosio_system_tester ) try {
 
    const auto& rlm = control->get_resource_limits_manager();
 
-   auto alice_initial_ram_usage = rlm.get_account_ram_usage(N(alice1111111));
+   auto alice_initial_ram_usage = rlm.get_account_ram_usage("alice1111111"_n);
 
    set_code( config::system_account_name, contracts::system_wasm() );
    set_abi(  config::system_account_name, contracts::system_abi().data() );
    produce_block();
-   BOOST_REQUIRE_EQUAL( control->pending_block_producer(), N(alice1111111) );
+   BOOST_REQUIRE_EQUAL( control->pending_block_producer(), "alice1111111"_n );
 
-   auto alice_prod_info2 = get_producer_info( N(alice1111111) );
+   auto alice_prod_info2 = get_producer_info( "alice1111111"_n );
    BOOST_REQUIRE_EQUAL( alice_prod_info2["is_active"], true );
 
    produce_block( fc::minutes(2) );
@@ -951,10 +951,10 @@ BOOST_FIXTURE_TEST_CASE( producer_wtmsig_transition, eosio_system_tester ) try {
    // producer_authority to begin with. This is verified below by ensuring the RAM usage of alice (who pays for the
    // producer object) does not increase.
 
-   auto alice_ram_usage = rlm.get_account_ram_usage(N(alice1111111));
+   auto alice_ram_usage = rlm.get_account_ram_usage("alice1111111"_n);
    BOOST_CHECK_EQUAL( alice_initial_ram_usage, alice_ram_usage );
 
-   auto alice_prod_info3 = get_producer_info( N(alice1111111) );
+   auto alice_prod_info3 = get_producer_info( "alice1111111"_n );
    if( alice_prod_info3.get_object().contains("producer_authority") ) {
       BOOST_CHECK_EQUAL( alice_prod_info3["producer_authority"][1]["threshold"], 0 );
    }
@@ -978,9 +978,9 @@ BOOST_FIXTURE_TEST_CASE( producer_wtmsig_transition, eosio_system_tester ) try {
    // by having the producer with the invalid authority simply call regproducer or regproducer2 to correct their
    // block signing authority.
 
-   BOOST_REQUIRE_EQUAL( success(), push_action( N(alice1111111), N(regproducer), mvo()
+   BOOST_REQUIRE_EQUAL( success(), push_action( "alice1111111"_n, "regproducer"_n, mvo()
                                                ("producer",  "alice1111111")
-                                               ("producer_key", get_public_key( N(alice1111111), "active") )
+                                               ("producer_key", get_public_key( "alice1111111"_n, "active") )
                                                ("url","")
                                                ("location", 0)
                         )
@@ -989,7 +989,7 @@ BOOST_FIXTURE_TEST_CASE( producer_wtmsig_transition, eosio_system_tester ) try {
    produce_block();
    produce_block( fc::minutes(2) );
 
-   auto alice_prod_info4 = get_producer_info( N(alice1111111) );
+   auto alice_prod_info4 = get_producer_info( "alice1111111"_n );
    BOOST_REQUIRE_EQUAL( alice_prod_info4["is_active"], true );
    const auto schedule_update4 = get_global_state()["last_producer_schedule_update"];
    BOOST_REQUIRE( schedule_update2 < schedule_update4 );
@@ -1001,9 +1001,9 @@ BOOST_FIXTURE_TEST_CASE( vote_for_producer, eosio_system_tester, * boost::unit_t
 
    issue_and_transfer( "alice1111111", core_sym::from_string("1000.0000"),  config::system_account_name );
    fc::variant params = producer_parameters_example(1);
-   BOOST_REQUIRE_EQUAL( success(), push_action( N(alice1111111), N(regproducer), mvo()
+   BOOST_REQUIRE_EQUAL( success(), push_action( "alice1111111"_n, "regproducer"_n, mvo()
                                                ("producer",  "alice1111111")
-                                               ("producer_key", get_public_key( N(alice1111111), "active") )
+                                               ("producer_key", get_public_key( "alice1111111"_n, "active") )
                                                ("url", "http://block.one")
                                                ("location", 0 )
                         )
@@ -1022,7 +1022,7 @@ BOOST_FIXTURE_TEST_CASE( vote_for_producer, eosio_system_tester, * boost::unit_t
    REQUIRE_MATCHING_OBJECT( voter( "bob111111111", core_sym::from_string("11.1111") ), get_voter_info( "bob111111111" ) );
 
    //bob111111111 votes for alice1111111
-   BOOST_REQUIRE_EQUAL( success(), vote( N(bob111111111), { N(alice1111111) } ) );
+   BOOST_REQUIRE_EQUAL( success(), vote( "bob111111111"_n, { "alice1111111"_n } ) );
 
    //check that producer parameters stay the same after voting
    prod = get_producer_info( "alice1111111" );
@@ -1035,7 +1035,7 @@ BOOST_FIXTURE_TEST_CASE( vote_for_producer, eosio_system_tester, * boost::unit_t
    REQUIRE_MATCHING_OBJECT( voter( "carol1111111", core_sym::from_string("22.2222") ), get_voter_info( "carol1111111" ) );
    BOOST_REQUIRE_EQUAL( core_sym::from_string("2977.7778"), get_balance( "carol1111111" ) );
    //carol1111111 votes for alice1111111
-   BOOST_REQUIRE_EQUAL( success(), vote( N(carol1111111), { N(alice1111111) } ) );
+   BOOST_REQUIRE_EQUAL( success(), vote( "carol1111111"_n, { "alice1111111"_n } ) );
 
    //new stake votes be added to alice1111111's total_votes
    prod = get_producer_info( "alice1111111" );
@@ -1044,7 +1044,7 @@ BOOST_FIXTURE_TEST_CASE( vote_for_producer, eosio_system_tester, * boost::unit_t
    //bob111111111 increases his stake
    BOOST_REQUIRE_EQUAL( success(), stake( "bob111111111", core_sym::from_string("33.0000"), core_sym::from_string("0.3333") ) );
    //alice1111111 stake with transfer to bob111111111
-   BOOST_REQUIRE_EQUAL( success(), stake_with_transfer( N(alice1111111), N(bob111111111), core_sym::from_string("22.0000"), core_sym::from_string("0.2222") ) );
+   BOOST_REQUIRE_EQUAL( success(), stake_with_transfer( "alice1111111"_n, "bob111111111"_n, core_sym::from_string("22.0000"), core_sym::from_string("0.2222") ) );
    //should increase alice1111111's total_votes
    prod = get_producer_info( "alice1111111" );
    BOOST_TEST_REQUIRE( stake2votes(core_sym::from_string("88.8888")) == prod["total_votes"].as_double() );
@@ -1058,7 +1058,7 @@ BOOST_FIXTURE_TEST_CASE( vote_for_producer, eosio_system_tester, * boost::unit_t
    BOOST_TEST_REQUIRE( stake2votes(core_sym::from_string("86.8886")) == prod["total_votes"].as_double() );
 
    //bob111111111 revokes his vote
-   BOOST_REQUIRE_EQUAL( success(), vote( N(bob111111111), vector<account_name>() ) );
+   BOOST_REQUIRE_EQUAL( success(), vote( "bob111111111"_n, vector<account_name>() ) );
 
    //should decrease alice1111111's total_votes
    prod = get_producer_info( "alice1111111" );
@@ -1087,20 +1087,20 @@ BOOST_FIXTURE_TEST_CASE( unregistered_producer_voting, eosio_system_tester, * bo
 
    //bob111111111 should not be able to vote for alice1111111 who is not a producer
    BOOST_REQUIRE_EQUAL( wasm_assert_msg( "producer alice1111111 is not registered" ),
-                        vote( N(bob111111111), { N(alice1111111) } ) );
+                        vote( "bob111111111"_n, { "alice1111111"_n } ) );
 
    //alice1111111 registers as a producer
    issue_and_transfer( "alice1111111", core_sym::from_string("1000.0000"),  config::system_account_name );
    fc::variant params = producer_parameters_example(1);
-   BOOST_REQUIRE_EQUAL( success(), push_action( N(alice1111111), N(regproducer), mvo()
+   BOOST_REQUIRE_EQUAL( success(), push_action( "alice1111111"_n, "regproducer"_n, mvo()
                                                ("producer",  "alice1111111")
-                                               ("producer_key", get_public_key( N(alice1111111), "active") )
+                                               ("producer_key", get_public_key( "alice1111111"_n, "active") )
                                                ("url", "")
                                                ("location", 0)
                         )
    );
    //and then unregisters
-   BOOST_REQUIRE_EQUAL( success(), push_action( N(alice1111111), N(unregprod), mvo()
+   BOOST_REQUIRE_EQUAL( success(), push_action( "alice1111111"_n, "unregprod"_n, mvo()
                                                ("producer",  "alice1111111")
                         )
    );
@@ -1110,7 +1110,7 @@ BOOST_FIXTURE_TEST_CASE( unregistered_producer_voting, eosio_system_tester, * bo
 
    //bob111111111 should not be able to vote for alice1111111 who is an unregistered producer
    BOOST_REQUIRE_EQUAL( wasm_assert_msg( "producer alice1111111 is not currently registered" ),
-                        vote( N(bob111111111), { N(alice1111111) } ) );
+                        vote( "bob111111111"_n, { "alice1111111"_n } ) );
 
 } FC_LOG_AND_RETHROW()
 
@@ -1122,7 +1122,7 @@ BOOST_FIXTURE_TEST_CASE( more_than_30_producer_voting, eosio_system_tester ) try
 
    //bob111111111 should not be able to vote for alice1111111 who is not a producer
    BOOST_REQUIRE_EQUAL( wasm_assert_msg( "attempt to vote for too many producers" ),
-                        vote( N(bob111111111), vector<account_name>(31, N(alice1111111)) ) );
+                        vote( "bob111111111"_n, vector<account_name>(31, "alice1111111"_n) ) );
 
 } FC_LOG_AND_RETHROW()
 
@@ -1135,9 +1135,9 @@ BOOST_FIXTURE_TEST_CASE( vote_same_producer_30_times, eosio_system_tester ) try 
    //alice1111111 becomes a producer
    issue_and_transfer( "alice1111111", core_sym::from_string("1000.0000"),  config::system_account_name );
    fc::variant params = producer_parameters_example(1);
-   BOOST_REQUIRE_EQUAL( success(), push_action( N(alice1111111), N(regproducer), mvo()
+   BOOST_REQUIRE_EQUAL( success(), push_action( "alice1111111"_n, "regproducer"_n, mvo()
                                                ("producer",  "alice1111111")
-                                               ("producer_key", get_public_key(N(alice1111111), "active") )
+                                               ("producer_key", get_public_key("alice1111111"_n, "active") )
                                                ("url", "")
                                                ("location", 0)
                         )
@@ -1145,7 +1145,7 @@ BOOST_FIXTURE_TEST_CASE( vote_same_producer_30_times, eosio_system_tester ) try 
 
    //bob111111111 should not be able to vote for alice1111111 who is not a producer
    BOOST_REQUIRE_EQUAL( wasm_assert_msg( "producer votes must be unique and sorted" ),
-                        vote( N(bob111111111), vector<account_name>(30, N(alice1111111)) ) );
+                        vote( "bob111111111"_n, vector<account_name>(30, "alice1111111"_n) ) );
 
    auto prod = get_producer_info( "alice1111111" );
    BOOST_TEST_REQUIRE( 0 == prod["total_votes"].as_double() );
@@ -1156,10 +1156,10 @@ BOOST_FIXTURE_TEST_CASE( vote_same_producer_30_times, eosio_system_tester ) try 
 BOOST_FIXTURE_TEST_CASE( producer_keep_votes, eosio_system_tester, * boost::unit_test::tolerance(1e+5) ) try {
    issue_and_transfer( "alice1111111", core_sym::from_string("1000.0000"),  config::system_account_name );
    fc::variant params = producer_parameters_example(1);
-   vector<char> key = fc::raw::pack( get_public_key( N(alice1111111), "active" ) );
-   BOOST_REQUIRE_EQUAL( success(), push_action( N(alice1111111), N(regproducer), mvo()
+   vector<char> key = fc::raw::pack( get_public_key( "alice1111111"_n, "active" ) );
+   BOOST_REQUIRE_EQUAL( success(), push_action( "alice1111111"_n, "regproducer"_n, mvo()
                                                ("producer",  "alice1111111")
-                                               ("producer_key", get_public_key( N(alice1111111), "active") )
+                                               ("producer_key", get_public_key( "alice1111111"_n, "active") )
                                                ("url", "")
                                                ("location", 0)
                         )
@@ -1171,13 +1171,13 @@ BOOST_FIXTURE_TEST_CASE( producer_keep_votes, eosio_system_tester, * boost::unit
    REQUIRE_MATCHING_OBJECT( voter( "bob111111111", core_sym::from_string("13.5791") ), get_voter_info( "bob111111111" ) );
 
    //bob111111111 votes for alice1111111
-   BOOST_REQUIRE_EQUAL( success(), vote(N(bob111111111), { N(alice1111111) } ) );
+   BOOST_REQUIRE_EQUAL( success(), vote("bob111111111"_n, { "alice1111111"_n } ) );
 
    auto prod = get_producer_info( "alice1111111" );
    BOOST_TEST_REQUIRE( stake2votes(core_sym::from_string("13.5791")) == prod["total_votes"].as_double() );
 
    //unregister producer
-   BOOST_REQUIRE_EQUAL( success(), push_action(N(alice1111111), N(unregprod), mvo()
+   BOOST_REQUIRE_EQUAL( success(), push_action("alice1111111"_n, "unregprod"_n, mvo()
                                                ("producer",  "alice1111111")
                         )
    );
@@ -1191,9 +1191,9 @@ BOOST_FIXTURE_TEST_CASE( producer_keep_votes, eosio_system_tester, * boost::unit
 
    //regtister the same producer again
    params = producer_parameters_example(2);
-   BOOST_REQUIRE_EQUAL( success(), push_action( N(alice1111111), N(regproducer), mvo()
+   BOOST_REQUIRE_EQUAL( success(), push_action( "alice1111111"_n, "regproducer"_n, mvo()
                                                ("producer",  "alice1111111")
-                                               ("producer_key", get_public_key( N(alice1111111), "active") )
+                                               ("producer_key", get_public_key( "alice1111111"_n, "active") )
                                                ("url", "")
                                                ("location", 0)
                         )
@@ -1204,9 +1204,9 @@ BOOST_FIXTURE_TEST_CASE( producer_keep_votes, eosio_system_tester, * boost::unit
 
    //change parameters
    params = producer_parameters_example(3);
-   BOOST_REQUIRE_EQUAL( success(), push_action( N(alice1111111), N(regproducer), mvo()
+   BOOST_REQUIRE_EQUAL( success(), push_action( "alice1111111"_n, "regproducer"_n, mvo()
                                                ("producer",  "alice1111111")
-                                               ("producer_key", get_public_key( N(alice1111111), "active") )
+                                               ("producer_key", get_public_key( "alice1111111"_n, "active") )
                                                ("url","")
                                                ("location", 0)
                         )
@@ -1223,20 +1223,20 @@ BOOST_FIXTURE_TEST_CASE( producer_keep_votes, eosio_system_tester, * boost::unit
 BOOST_FIXTURE_TEST_CASE( vote_for_two_producers, eosio_system_tester, * boost::unit_test::tolerance(1e+5) ) try {
    //alice1111111 becomes a producer
    fc::variant params = producer_parameters_example(1);
-   auto key = get_public_key( N(alice1111111), "active" );
-   BOOST_REQUIRE_EQUAL( success(), push_action( N(alice1111111), N(regproducer), mvo()
+   auto key = get_public_key( "alice1111111"_n, "active" );
+   BOOST_REQUIRE_EQUAL( success(), push_action( "alice1111111"_n, "regproducer"_n, mvo()
                                                ("producer",  "alice1111111")
-                                               ("producer_key", get_public_key( N(alice1111111), "active") )
+                                               ("producer_key", get_public_key( "alice1111111"_n, "active") )
                                                ("url","")
                                                ("location", 0)
                         )
    );
    //bob111111111 becomes a producer
    params = producer_parameters_example(2);
-   key = get_public_key( N(bob111111111), "active" );
-   BOOST_REQUIRE_EQUAL( success(), push_action( N(bob111111111), N(regproducer), mvo()
+   key = get_public_key( "bob111111111"_n, "active" );
+   BOOST_REQUIRE_EQUAL( success(), push_action( "bob111111111"_n, "regproducer"_n, mvo()
                                                ("producer",  "bob111111111")
-                                               ("producer_key", get_public_key( N(alice1111111), "active") )
+                                               ("producer_key", get_public_key( "alice1111111"_n, "active") )
                                                ("url","")
                                                ("location", 0)
                         )
@@ -1245,7 +1245,7 @@ BOOST_FIXTURE_TEST_CASE( vote_for_two_producers, eosio_system_tester, * boost::u
    //carol1111111 votes for alice1111111 and bob111111111
    issue_and_transfer( "carol1111111", core_sym::from_string("1000.0000"),  config::system_account_name );
    BOOST_REQUIRE_EQUAL( success(), stake( "carol1111111", core_sym::from_string("15.0005"), core_sym::from_string("5.0000") ) );
-   BOOST_REQUIRE_EQUAL( success(), vote( N(carol1111111), { N(alice1111111), N(bob111111111) } ) );
+   BOOST_REQUIRE_EQUAL( success(), vote( "carol1111111"_n, { "alice1111111"_n, "bob111111111"_n } ) );
 
    auto alice_info = get_producer_info( "alice1111111" );
    BOOST_TEST_REQUIRE( stake2votes(core_sym::from_string("20.0005")) == alice_info["total_votes"].as_double() );
@@ -1253,7 +1253,7 @@ BOOST_FIXTURE_TEST_CASE( vote_for_two_producers, eosio_system_tester, * boost::u
    BOOST_TEST_REQUIRE( stake2votes(core_sym::from_string("20.0005")) == bob_info["total_votes"].as_double() );
 
    //carol1111111 votes for alice1111111 (but revokes vote for bob111111111)
-   BOOST_REQUIRE_EQUAL( success(), vote( N(carol1111111), { N(alice1111111) } ) );
+   BOOST_REQUIRE_EQUAL( success(), vote( "carol1111111"_n, { "alice1111111"_n } ) );
 
    alice_info = get_producer_info( "alice1111111" );
    BOOST_TEST_REQUIRE( stake2votes(core_sym::from_string("20.0005")) == alice_info["total_votes"].as_double() );
@@ -1263,7 +1263,7 @@ BOOST_FIXTURE_TEST_CASE( vote_for_two_producers, eosio_system_tester, * boost::u
    //alice1111111 votes for herself and bob111111111
    issue_and_transfer( "alice1111111", core_sym::from_string("2.0000"),  config::system_account_name );
    BOOST_REQUIRE_EQUAL( success(), stake( "alice1111111", core_sym::from_string("1.0000"), core_sym::from_string("1.0000") ) );
-   BOOST_REQUIRE_EQUAL( success(), vote(N(alice1111111), { N(alice1111111), N(bob111111111) } ) );
+   BOOST_REQUIRE_EQUAL( success(), vote("alice1111111"_n, { "alice1111111"_n, "bob111111111"_n } ) );
 
    alice_info = get_producer_info( "alice1111111" );
    BOOST_TEST_REQUIRE( stake2votes(core_sym::from_string("22.0005")) == alice_info["total_votes"].as_double() );
@@ -1276,15 +1276,15 @@ BOOST_FIXTURE_TEST_CASE( vote_for_two_producers, eosio_system_tester, * boost::u
 
 BOOST_FIXTURE_TEST_CASE( proxy_register_unregister_keeps_stake, eosio_system_tester ) try {
    //register proxy by first action for this user ever
-   BOOST_REQUIRE_EQUAL( success(), push_action(N(alice1111111), N(regproxy), mvo()
+   BOOST_REQUIRE_EQUAL( success(), push_action("alice1111111"_n, "regproxy"_n, mvo()
                                                ("proxy",  "alice1111111")
                                                ("isproxy", true )
                         )
    );
-   REQUIRE_MATCHING_OBJECT( proxy( N(alice1111111) ), get_voter_info( "alice1111111" ) );
+   REQUIRE_MATCHING_OBJECT( proxy( "alice1111111"_n ), get_voter_info( "alice1111111" ) );
 
    //unregister proxy
-   BOOST_REQUIRE_EQUAL( success(), push_action(N(alice1111111), N(regproxy), mvo()
+   BOOST_REQUIRE_EQUAL( success(), push_action("alice1111111"_n, "regproxy"_n, mvo()
                                                ("proxy",  "alice1111111")
                                                ("isproxy", false)
                         )
@@ -1294,14 +1294,14 @@ BOOST_FIXTURE_TEST_CASE( proxy_register_unregister_keeps_stake, eosio_system_tes
    //stake and then register as a proxy
    issue_and_transfer( "bob111111111", core_sym::from_string("1000.0000"),  config::system_account_name );
    BOOST_REQUIRE_EQUAL( success(), stake( "bob111111111", core_sym::from_string("200.0002"), core_sym::from_string("100.0001") ) );
-   BOOST_REQUIRE_EQUAL( success(), push_action( N(bob111111111), N(regproxy), mvo()
+   BOOST_REQUIRE_EQUAL( success(), push_action( "bob111111111"_n, "regproxy"_n, mvo()
                                                ("proxy",  "bob111111111")
                                                ("isproxy", true)
                         )
    );
-   REQUIRE_MATCHING_OBJECT( proxy( N(bob111111111) )( "staked", 3000003 ), get_voter_info( "bob111111111" ) );
+   REQUIRE_MATCHING_OBJECT( proxy( "bob111111111"_n )( "staked", 3000003 ), get_voter_info( "bob111111111" ) );
    //unrgister and check that stake is still in place
-   BOOST_REQUIRE_EQUAL( success(), push_action( N(bob111111111), N(regproxy), mvo()
+   BOOST_REQUIRE_EQUAL( success(), push_action( "bob111111111"_n, "regproxy"_n, mvo()
                                                ("proxy",  "bob111111111")
                                                ("isproxy", false)
                         )
@@ -1309,7 +1309,7 @@ BOOST_FIXTURE_TEST_CASE( proxy_register_unregister_keeps_stake, eosio_system_tes
    REQUIRE_MATCHING_OBJECT( voter( "bob111111111", core_sym::from_string("300.0003") ), get_voter_info( "bob111111111" ) );
 
    //register as a proxy and then stake
-   BOOST_REQUIRE_EQUAL( success(), push_action( N(carol1111111), N(regproxy), mvo()
+   BOOST_REQUIRE_EQUAL( success(), push_action( "carol1111111"_n, "regproxy"_n, mvo()
                                                ("proxy",  "carol1111111")
                                                ("isproxy", true)
                         )
@@ -1317,10 +1317,10 @@ BOOST_FIXTURE_TEST_CASE( proxy_register_unregister_keeps_stake, eosio_system_tes
    issue_and_transfer( "carol1111111", core_sym::from_string("1000.0000"),  config::system_account_name );
    BOOST_REQUIRE_EQUAL( success(), stake( "carol1111111", core_sym::from_string("246.0002"), core_sym::from_string("531.0001") ) );
    //check that both proxy flag and stake a correct
-   REQUIRE_MATCHING_OBJECT( proxy( N(carol1111111) )( "staked", 7770003 ), get_voter_info( "carol1111111" ) );
+   REQUIRE_MATCHING_OBJECT( proxy( "carol1111111"_n )( "staked", 7770003 ), get_voter_info( "carol1111111" ) );
 
    //unregister
-   BOOST_REQUIRE_EQUAL( success(), push_action( N(carol1111111), N(regproxy), mvo()
+   BOOST_REQUIRE_EQUAL( success(), push_action( "carol1111111"_n, "regproxy"_n, mvo()
                                                 ("proxy",  "carol1111111")
                                                 ("isproxy", false)
                         )
@@ -1333,31 +1333,31 @@ BOOST_FIXTURE_TEST_CASE( proxy_register_unregister_keeps_stake, eosio_system_tes
 BOOST_FIXTURE_TEST_CASE( proxy_stake_unstake_keeps_proxy_flag, eosio_system_tester ) try {
    cross_15_percent_threshold();
 
-   BOOST_REQUIRE_EQUAL( success(), push_action( N(alice1111111), N(regproxy), mvo()
+   BOOST_REQUIRE_EQUAL( success(), push_action( "alice1111111"_n, "regproxy"_n, mvo()
                                                ("proxy",  "alice1111111")
                                                ("isproxy", true)
                         )
    );
    issue_and_transfer( "alice1111111", core_sym::from_string("1000.0000"),  config::system_account_name );
-   REQUIRE_MATCHING_OBJECT( proxy( N(alice1111111) ), get_voter_info( "alice1111111" ) );
+   REQUIRE_MATCHING_OBJECT( proxy( "alice1111111"_n ), get_voter_info( "alice1111111" ) );
 
    //stake
    BOOST_REQUIRE_EQUAL( success(), stake( "alice1111111", core_sym::from_string("100.0000"), core_sym::from_string("50.0000") ) );
    //check that account is still a proxy
-   REQUIRE_MATCHING_OBJECT( proxy( N(alice1111111) )( "staked", 1500000 ), get_voter_info( "alice1111111" ) );
+   REQUIRE_MATCHING_OBJECT( proxy( "alice1111111"_n )( "staked", 1500000 ), get_voter_info( "alice1111111" ) );
 
    //stake more
    BOOST_REQUIRE_EQUAL( success(), stake( "alice1111111", core_sym::from_string("30.0000"), core_sym::from_string("20.0000") ) );
    //check that account is still a proxy
-   REQUIRE_MATCHING_OBJECT( proxy( N(alice1111111) )("staked", 2000000 ), get_voter_info( "alice1111111" ) );
+   REQUIRE_MATCHING_OBJECT( proxy( "alice1111111"_n )("staked", 2000000 ), get_voter_info( "alice1111111" ) );
 
    //unstake more
    BOOST_REQUIRE_EQUAL( success(), unstake( "alice1111111", core_sym::from_string("65.0000"), core_sym::from_string("35.0000") ) );
-   REQUIRE_MATCHING_OBJECT( proxy( N(alice1111111) )("staked", 1000000 ), get_voter_info( "alice1111111" ) );
+   REQUIRE_MATCHING_OBJECT( proxy( "alice1111111"_n )("staked", 1000000 ), get_voter_info( "alice1111111" ) );
 
    //unstake the rest
    BOOST_REQUIRE_EQUAL( success(), unstake( "alice1111111", core_sym::from_string("65.0000"), core_sym::from_string("35.0000") ) );
-   REQUIRE_MATCHING_OBJECT( proxy( N(alice1111111) )( "staked", 0 ), get_voter_info( "alice1111111" ) );
+   REQUIRE_MATCHING_OBJECT( proxy( "alice1111111"_n )( "staked", 0 ), get_voter_info( "alice1111111" ) );
 
 } FC_LOG_AND_RETHROW()
 
@@ -1365,13 +1365,13 @@ BOOST_FIXTURE_TEST_CASE( proxy_stake_unstake_keeps_proxy_flag, eosio_system_test
 BOOST_FIXTURE_TEST_CASE( proxy_actions_affect_producers, eosio_system_tester, * boost::unit_test::tolerance(1e+5) ) try {
    cross_15_percent_threshold();
 
-   create_accounts_with_resources( {  N(defproducer1), N(defproducer2), N(defproducer3) } );
-   BOOST_REQUIRE_EQUAL( success(), regproducer( N(defproducer1), 1) );
-   BOOST_REQUIRE_EQUAL( success(), regproducer( N(defproducer2), 2) );
-   BOOST_REQUIRE_EQUAL( success(), regproducer( N(defproducer3), 3) );
+   create_accounts_with_resources( {  "defproducer1"_n, "defproducer2"_n, "defproducer3"_n } );
+   BOOST_REQUIRE_EQUAL( success(), regproducer( "defproducer1"_n, 1) );
+   BOOST_REQUIRE_EQUAL( success(), regproducer( "defproducer2"_n, 2) );
+   BOOST_REQUIRE_EQUAL( success(), regproducer( "defproducer3"_n, 3) );
 
    //register as a proxy
-   BOOST_REQUIRE_EQUAL( success(), push_action( N(alice1111111), N(regproxy), mvo()
+   BOOST_REQUIRE_EQUAL( success(), push_action( "alice1111111"_n, "regproxy"_n, mvo()
                                                 ("proxy",  "alice1111111")
                                                 ("isproxy", true)
                         )
@@ -1380,23 +1380,23 @@ BOOST_FIXTURE_TEST_CASE( proxy_actions_affect_producers, eosio_system_tester, * 
    //accumulate proxied votes
    issue_and_transfer( "bob111111111", core_sym::from_string("1000.0000"),  config::system_account_name );
    BOOST_REQUIRE_EQUAL( success(), stake( "bob111111111", core_sym::from_string("100.0002"), core_sym::from_string("50.0001") ) );
-   BOOST_REQUIRE_EQUAL( success(), vote(N(bob111111111), vector<account_name>(), N(alice1111111) ) );
-   REQUIRE_MATCHING_OBJECT( proxy( N(alice1111111) )( "proxied_vote_weight", stake2votes(core_sym::from_string("150.0003")) ), get_voter_info( "alice1111111" ) );
+   BOOST_REQUIRE_EQUAL( success(), vote("bob111111111"_n, vector<account_name>(), "alice1111111"_n ) );
+   REQUIRE_MATCHING_OBJECT( proxy( "alice1111111"_n )( "proxied_vote_weight", stake2votes(core_sym::from_string("150.0003")) ), get_voter_info( "alice1111111" ) );
 
    //vote for producers
-   BOOST_REQUIRE_EQUAL( success(), vote(N(alice1111111), { N(defproducer1), N(defproducer2) } ) );
+   BOOST_REQUIRE_EQUAL( success(), vote("alice1111111"_n, { "defproducer1"_n, "defproducer2"_n } ) );
    BOOST_TEST_REQUIRE( stake2votes(core_sym::from_string("150.0003")) == get_producer_info( "defproducer1" )["total_votes"].as_double() );
    BOOST_TEST_REQUIRE( stake2votes(core_sym::from_string("150.0003")) == get_producer_info( "defproducer2" )["total_votes"].as_double() );
    BOOST_TEST_REQUIRE( 0 == get_producer_info( "defproducer3" )["total_votes"].as_double() );
 
    //vote for another producers
-   BOOST_REQUIRE_EQUAL( success(), vote( N(alice1111111), { N(defproducer1), N(defproducer3) } ) );
+   BOOST_REQUIRE_EQUAL( success(), vote( "alice1111111"_n, { "defproducer1"_n, "defproducer3"_n } ) );
    BOOST_TEST_REQUIRE( stake2votes(core_sym::from_string("150.0003")) == get_producer_info( "defproducer1" )["total_votes"].as_double() );
    BOOST_REQUIRE_EQUAL( 0, get_producer_info( "defproducer2" )["total_votes"].as_double() );
    BOOST_TEST_REQUIRE( stake2votes(core_sym::from_string("150.0003")) == get_producer_info( "defproducer3" )["total_votes"].as_double() );
 
    //unregister proxy
-   BOOST_REQUIRE_EQUAL( success(), push_action( N(alice1111111), N(regproxy), mvo()
+   BOOST_REQUIRE_EQUAL( success(), push_action( "alice1111111"_n, "regproxy"_n, mvo()
                                                 ("proxy",  "alice1111111")
                                                 ("isproxy", false)
                         )
@@ -1407,7 +1407,7 @@ BOOST_FIXTURE_TEST_CASE( proxy_actions_affect_producers, eosio_system_tester, * 
    BOOST_REQUIRE_EQUAL( 0, get_producer_info( "defproducer3" )["total_votes"].as_double() );
 
    //register proxy again
-   BOOST_REQUIRE_EQUAL( success(), push_action( N(alice1111111), N(regproxy), mvo()
+   BOOST_REQUIRE_EQUAL( success(), push_action( "alice1111111"_n, "regproxy"_n, mvo()
                                                 ("proxy",  "alice1111111")
                                                 ("isproxy", true)
                         )
@@ -1439,22 +1439,22 @@ BOOST_FIXTURE_TEST_CASE(producer_pay, eosio_system_tester, * boost::unit_test::t
 
 
    const asset large_asset = core_sym::from_string("80.0000");
-   create_account_with_resources( N(defproducera), config::system_account_name, core_sym::from_string("1.0000"), false, large_asset, large_asset );
-   create_account_with_resources( N(defproducerb), config::system_account_name, core_sym::from_string("1.0000"), false, large_asset, large_asset );
-   create_account_with_resources( N(defproducerc), config::system_account_name, core_sym::from_string("1.0000"), false, large_asset, large_asset );
+   create_account_with_resources( "defproducera"_n, config::system_account_name, core_sym::from_string("1.0000"), false, large_asset, large_asset );
+   create_account_with_resources( "defproducerb"_n, config::system_account_name, core_sym::from_string("1.0000"), false, large_asset, large_asset );
+   create_account_with_resources( "defproducerc"_n, config::system_account_name, core_sym::from_string("1.0000"), false, large_asset, large_asset );
 
-   create_account_with_resources( N(producvotera), config::system_account_name, core_sym::from_string("1.0000"), false, large_asset, large_asset );
-   create_account_with_resources( N(producvoterb), config::system_account_name, core_sym::from_string("1.0000"), false, large_asset, large_asset );
+   create_account_with_resources( "producvotera"_n, config::system_account_name, core_sym::from_string("1.0000"), false, large_asset, large_asset );
+   create_account_with_resources( "producvoterb"_n, config::system_account_name, core_sym::from_string("1.0000"), false, large_asset, large_asset );
 
-   BOOST_REQUIRE_EQUAL(success(), regproducer(N(defproducera)));
+   BOOST_REQUIRE_EQUAL(success(), regproducer("defproducera"_n));
    produce_block(fc::hours(24));
-   auto prod = get_producer_info( N(defproducera) );
+   auto prod = get_producer_info( "defproducera"_n );
    BOOST_REQUIRE_EQUAL("defproducera", prod["owner"].as_string());
    BOOST_REQUIRE_EQUAL(0, prod["total_votes"].as_double());
 
    transfer( config::system_account_name, "producvotera", core_sym::from_string("400000000.0000"), config::system_account_name);
    BOOST_REQUIRE_EQUAL(success(), stake("producvotera", core_sym::from_string("100000000.0000"), core_sym::from_string("100000000.0000")));
-   BOOST_REQUIRE_EQUAL(success(), vote( N(producvotera), { N(defproducera) }));
+   BOOST_REQUIRE_EQUAL(success(), vote( "producvotera"_n, { "defproducera"_n }));
    // defproducera is the only active producer
    // produce enough blocks so new schedule kicks in and defproducera produces some blocks
    {
@@ -1464,7 +1464,7 @@ BOOST_FIXTURE_TEST_CASE(producer_pay, eosio_system_tester, * boost::unit_test::t
       const uint64_t initial_claim_time        = microseconds_since_epoch_of_iso_string( initial_global_state["last_pervote_bucket_fill"] );
       const int64_t  initial_pervote_bucket    = initial_global_state["pervote_bucket"].as<int64_t>();
       const int64_t  initial_perblock_bucket   = initial_global_state["perblock_bucket"].as<int64_t>();
-      const int64_t  initial_savings           = get_balance(N(eosio.saving)).get_amount();
+      const int64_t  initial_savings           = get_balance("eosio.saving"_n).get_amount();
       const uint32_t initial_tot_unpaid_blocks = initial_global_state["total_unpaid_blocks"].as<uint32_t>();
 
       prod = get_producer_info("defproducera");
@@ -1474,22 +1474,22 @@ BOOST_FIXTURE_TEST_CASE(producer_pay, eosio_system_tester, * boost::unit_test::t
       BOOST_REQUIRE_EQUAL(initial_tot_unpaid_blocks, unpaid_blocks);
 
       const asset initial_supply  = get_token_supply();
-      const asset initial_balance = get_balance(N(defproducera));
+      const asset initial_balance = get_balance("defproducera"_n);
 
-      BOOST_REQUIRE_EQUAL(success(), push_action(N(defproducera), N(claimrewards), mvo()("owner", "defproducera")));
+      BOOST_REQUIRE_EQUAL(success(), push_action("defproducera"_n, "claimrewards"_n, mvo()("owner", "defproducera")));
 
       const auto     global_state      = get_global_state();
       const uint64_t claim_time        = microseconds_since_epoch_of_iso_string( global_state["last_pervote_bucket_fill"] );
       const int64_t  pervote_bucket    = global_state["pervote_bucket"].as<int64_t>();
       const int64_t  perblock_bucket   = global_state["perblock_bucket"].as<int64_t>();
-      const int64_t  savings           = get_balance(N(eosio.saving)).get_amount();
+      const int64_t  savings           = get_balance("eosio.saving"_n).get_amount();
       const uint32_t tot_unpaid_blocks = global_state["total_unpaid_blocks"].as<uint32_t>();
 
       prod = get_producer_info("defproducera");
       BOOST_REQUIRE_EQUAL(1, prod["unpaid_blocks"].as<uint32_t>());
       BOOST_REQUIRE_EQUAL(1, tot_unpaid_blocks);
       const asset supply  = get_token_supply();
-      const asset balance = get_balance(N(defproducera));
+      const asset balance = get_balance("defproducera"_n);
 
       BOOST_REQUIRE_EQUAL(claim_time, microseconds_since_epoch_of_iso_string( prod["last_claim_time"] ));
 
@@ -1522,14 +1522,14 @@ BOOST_FIXTURE_TEST_CASE(producer_pay, eosio_system_tester, * boost::unit_test::t
 
    {
       BOOST_REQUIRE_EQUAL(wasm_assert_msg("already claimed rewards within past day"),
-                          push_action(N(defproducera), N(claimrewards), mvo()("owner", "defproducera")));
+                          push_action("defproducera"_n, "claimrewards"_n, mvo()("owner", "defproducera")));
    }
 
    // defproducera waits for 23 hours and 55 minutes, can't claim rewards yet
    {
       produce_block(fc::seconds(23 * 3600 + 55 * 60));
       BOOST_REQUIRE_EQUAL(wasm_assert_msg("already claimed rewards within past day"),
-                          push_action(N(defproducera), N(claimrewards), mvo()("owner", "defproducera")));
+                          push_action("defproducera"_n, "claimrewards"_n, mvo()("owner", "defproducera")));
    }
 
    // wait 5 more minutes, defproducera can now claim rewards again
@@ -1540,7 +1540,7 @@ BOOST_FIXTURE_TEST_CASE(producer_pay, eosio_system_tester, * boost::unit_test::t
       const uint64_t initial_claim_time        = microseconds_since_epoch_of_iso_string( initial_global_state["last_pervote_bucket_fill"] );
       const int64_t  initial_pervote_bucket    = initial_global_state["pervote_bucket"].as<int64_t>();
       const int64_t  initial_perblock_bucket   = initial_global_state["perblock_bucket"].as<int64_t>();
-      const int64_t  initial_savings           = get_balance(N(eosio.saving)).get_amount();
+      const int64_t  initial_savings           = get_balance("eosio.saving"_n).get_amount();
       const uint32_t initial_tot_unpaid_blocks = initial_global_state["total_unpaid_blocks"].as<uint32_t>();
       const double   initial_tot_vote_weight   = initial_global_state["total_producer_vote_weight"].as<double>();
 
@@ -1555,22 +1555,22 @@ BOOST_FIXTURE_TEST_CASE(producer_pay, eosio_system_tester, * boost::unit_test::t
       BOOST_REQUIRE_EQUAL(initial_tot_unpaid_blocks, unpaid_blocks);
 
       const asset initial_supply  = get_token_supply();
-      const asset initial_balance = get_balance(N(defproducera));
+      const asset initial_balance = get_balance("defproducera"_n);
 
-      BOOST_REQUIRE_EQUAL(success(), push_action(N(defproducera), N(claimrewards), mvo()("owner", "defproducera")));
+      BOOST_REQUIRE_EQUAL(success(), push_action("defproducera"_n, "claimrewards"_n, mvo()("owner", "defproducera")));
 
       const auto global_state          = get_global_state();
       const uint64_t claim_time        = microseconds_since_epoch_of_iso_string( global_state["last_pervote_bucket_fill"] );
       const int64_t  pervote_bucket    = global_state["pervote_bucket"].as<int64_t>();
       const int64_t  perblock_bucket   = global_state["perblock_bucket"].as<int64_t>();
-      const int64_t  savings           = get_balance(N(eosio.saving)).get_amount();
+      const int64_t  savings           = get_balance("eosio.saving"_n).get_amount();
       const uint32_t tot_unpaid_blocks = global_state["total_unpaid_blocks"].as<uint32_t>();
 
       prod = get_producer_info("defproducera");
       BOOST_REQUIRE_EQUAL(1, prod["unpaid_blocks"].as<uint32_t>());
       BOOST_REQUIRE_EQUAL(1, tot_unpaid_blocks);
       const asset supply  = get_token_supply();
-      const asset balance = get_balance(N(defproducera));
+      const asset balance = get_balance("defproducera"_n);
 
       BOOST_REQUIRE_EQUAL(claim_time, microseconds_since_epoch_of_iso_string( prod["last_claim_time"] ));
       auto usecs_between_fills = claim_time - initial_claim_time;
@@ -1596,26 +1596,26 @@ BOOST_FIXTURE_TEST_CASE(producer_pay, eosio_system_tester, * boost::unit_test::t
    // defproducerb tries to claim rewards but he's not on the list
    {
       BOOST_REQUIRE_EQUAL(wasm_assert_msg("unable to find key"),
-                          push_action(N(defproducerb), N(claimrewards), mvo()("owner", "defproducerb")));
+                          push_action("defproducerb"_n, "claimrewards"_n, mvo()("owner", "defproducerb")));
    }
 
    // test stability over a year
    {
-      regproducer(N(defproducerb));
-      regproducer(N(defproducerc));
+      regproducer("defproducerb"_n);
+      regproducer("defproducerc"_n);
       produce_block(fc::hours(24));
       const asset   initial_supply  = get_token_supply();
-      const int64_t initial_savings = get_balance(N(eosio.saving)).get_amount();
+      const int64_t initial_savings = get_balance("eosio.saving"_n).get_amount();
       for (uint32_t i = 0; i < 7 * 52; ++i) {
          produce_block(fc::seconds(8 * 3600));
-         BOOST_REQUIRE_EQUAL(success(), push_action(N(defproducerc), N(claimrewards), mvo()("owner", "defproducerc")));
+         BOOST_REQUIRE_EQUAL(success(), push_action("defproducerc"_n, "claimrewards"_n, mvo()("owner", "defproducerc")));
          produce_block(fc::seconds(8 * 3600));
-         BOOST_REQUIRE_EQUAL(success(), push_action(N(defproducerb), N(claimrewards), mvo()("owner", "defproducerb")));
+         BOOST_REQUIRE_EQUAL(success(), push_action("defproducerb"_n, "claimrewards"_n, mvo()("owner", "defproducerb")));
          produce_block(fc::seconds(8 * 3600));
-         BOOST_REQUIRE_EQUAL(success(), push_action(N(defproducera), N(claimrewards), mvo()("owner", "defproducera")));
+         BOOST_REQUIRE_EQUAL(success(), push_action("defproducera"_n, "claimrewards"_n, mvo()("owner", "defproducera")));
       }
       const asset   supply  = get_token_supply();
-      const int64_t savings = get_balance(N(eosio.saving)).get_amount();
+      const int64_t savings = get_balance("eosio.saving"_n).get_amount();
       // Amount issued per year is very close to the 5% inflation target. Small difference (500 tokens out of 50'000'000 issued)
       // is due to compounding every 8 hours in this test as opposed to theoretical continuous compounding
       BOOST_REQUIRE(500 * 10000 > int64_t(double(initial_supply.get_amount()) * double(0.05)) - (supply.get_amount() - initial_supply.get_amount()));
@@ -1638,22 +1638,22 @@ BOOST_FIXTURE_TEST_CASE(change_inflation, eosio_system_tester) try {
 
    {
       const asset large_asset = core_sym::from_string("80.0000");
-      create_account_with_resources( N(defproducera), config::system_account_name, core_sym::from_string("1.0000"), false, large_asset, large_asset );
-      create_account_with_resources( N(defproducerb), config::system_account_name, core_sym::from_string("1.0000"), false, large_asset, large_asset );
-      create_account_with_resources( N(defproducerc), config::system_account_name, core_sym::from_string("1.0000"), false, large_asset, large_asset );
+      create_account_with_resources( "defproducera"_n, config::system_account_name, core_sym::from_string("1.0000"), false, large_asset, large_asset );
+      create_account_with_resources( "defproducerb"_n, config::system_account_name, core_sym::from_string("1.0000"), false, large_asset, large_asset );
+      create_account_with_resources( "defproducerc"_n, config::system_account_name, core_sym::from_string("1.0000"), false, large_asset, large_asset );
 
-      create_account_with_resources( N(producvotera), config::system_account_name, core_sym::from_string("1.0000"), false, large_asset, large_asset );
-      create_account_with_resources( N(producvoterb), config::system_account_name, core_sym::from_string("1.0000"), false, large_asset, large_asset );
+      create_account_with_resources( "producvotera"_n, config::system_account_name, core_sym::from_string("1.0000"), false, large_asset, large_asset );
+      create_account_with_resources( "producvoterb"_n, config::system_account_name, core_sym::from_string("1.0000"), false, large_asset, large_asset );
 
-      BOOST_REQUIRE_EQUAL(success(), regproducer(N(defproducera)));
-      BOOST_REQUIRE_EQUAL(success(), regproducer(N(defproducerb)));
-      BOOST_REQUIRE_EQUAL(success(), regproducer(N(defproducerc)));
+      BOOST_REQUIRE_EQUAL(success(), regproducer("defproducera"_n));
+      BOOST_REQUIRE_EQUAL(success(), regproducer("defproducerb"_n));
+      BOOST_REQUIRE_EQUAL(success(), regproducer("defproducerc"_n));
 
       produce_block(fc::hours(24));
 
       transfer( config::system_account_name, "producvotera", core_sym::from_string("400000000.0000"), config::system_account_name);
       BOOST_REQUIRE_EQUAL(success(), stake("producvotera", core_sym::from_string("100000000.0000"), core_sym::from_string("100000000.0000")));
-      BOOST_REQUIRE_EQUAL(success(), vote( N(producvotera), { N(defproducera),N(defproducerb),N(defproducerc) }));
+      BOOST_REQUIRE_EQUAL(success(), vote( "producvotera"_n, { "defproducera"_n,"defproducerb"_n,"defproducerc"_n }));
 
       auto run_for_1year = [this](int64_t annual_rate, int64_t inflation_pay_factor, int64_t votepay_factor) {
 
@@ -1667,17 +1667,17 @@ BOOST_FIXTURE_TEST_CASE(change_inflation, eosio_system_tester) try {
 
          produce_block(fc::hours(24));
          const asset   initial_supply  = get_token_supply();
-         const int64_t initial_savings = get_balance(N(eosio.saving)).get_amount();
+         const int64_t initial_savings = get_balance("eosio.saving"_n).get_amount();
          for (uint32_t i = 0; i < 7 * 52; ++i) {
             produce_block(fc::seconds(8 * 3600));
-            BOOST_REQUIRE_EQUAL(success(), push_action(N(defproducerc), N(claimrewards), mvo()("owner", "defproducerc")));
+            BOOST_REQUIRE_EQUAL(success(), push_action("defproducerc"_n, "claimrewards"_n, mvo()("owner", "defproducerc")));
             produce_block(fc::seconds(8 * 3600));
-            BOOST_REQUIRE_EQUAL(success(), push_action(N(defproducerb), N(claimrewards), mvo()("owner", "defproducerb")));
+            BOOST_REQUIRE_EQUAL(success(), push_action("defproducerb"_n, "claimrewards"_n, mvo()("owner", "defproducerb")));
             produce_block(fc::seconds(8 * 3600));
-            BOOST_REQUIRE_EQUAL(success(), push_action(N(defproducera), N(claimrewards), mvo()("owner", "defproducera")));
+            BOOST_REQUIRE_EQUAL(success(), push_action("defproducera"_n, "claimrewards"_n, mvo()("owner", "defproducera")));
          }
          const asset   final_supply  = get_token_supply();
-         const int64_t final_savings = get_balance(N(eosio.saving)).get_amount();
+         const int64_t final_savings = get_balance("eosio.saving"_n).get_amount();
 
          double computed_new_tokens = double(final_supply.get_amount() - initial_supply.get_amount());
          double theoretical_new_tokens = double(initial_supply.get_amount())*inflation;
@@ -1721,23 +1721,23 @@ BOOST_FIXTURE_TEST_CASE(change_inflation, eosio_system_tester) try {
 BOOST_AUTO_TEST_CASE(extreme_inflation) try {
    eosio_system_tester t(eosio_system_tester::setup_level::minimal);
    symbol core_symbol{CORE_SYM};
-   t.create_currency( N(eosio.token), config::system_account_name, asset((1ll << 62) - 1, core_symbol) );
+   t.create_currency( "eosio.token"_n, config::system_account_name, asset((1ll << 62) - 1, core_symbol) );
    t.issue( asset(10000000000000, core_symbol) );
    t.deploy_contract();
    t.produce_block();
-   t.create_account_with_resources(N(defproducera), config::system_account_name, core_sym::from_string("1.0000"), false);
-   BOOST_REQUIRE_EQUAL(t.success(), t.regproducer(N(defproducera)));
+   t.create_account_with_resources("defproducera"_n, config::system_account_name, core_sym::from_string("1.0000"), false);
+   BOOST_REQUIRE_EQUAL(t.success(), t.regproducer("defproducera"_n));
    t.transfer( config::system_account_name, "defproducera", core_sym::from_string("200000000.0000"), config::system_account_name);
    BOOST_REQUIRE_EQUAL(t.success(), t.stake("defproducera", core_sym::from_string("100000000.0000"), core_sym::from_string("100000000.0000")));
-   BOOST_REQUIRE_EQUAL(t.success(), t.vote( N(defproducera), { N(defproducera) }));
+   BOOST_REQUIRE_EQUAL(t.success(), t.vote( "defproducera"_n, { "defproducera"_n }));
    t.produce_blocks(4);
    t.produce_block(fc::hours(24));
 
-   BOOST_REQUIRE_EQUAL(t.success(), t.push_action(N(defproducera), N(claimrewards), mvo()("owner", "defproducera")));
+   BOOST_REQUIRE_EQUAL(t.success(), t.push_action("defproducera"_n, "claimrewards"_n, mvo()("owner", "defproducera")));
    t.produce_block();
    asset current_supply;
    {
-      vector<char> data = t.get_row_by_account( N(eosio.token), name(core_symbol.to_symbol_code().value), N(stat), account_name(core_symbol.to_symbol_code().value) );
+      vector<char> data = t.get_row_by_account( "eosio.token"_n, name(core_symbol.to_symbol_code().value), "stat"_n, account_name(core_symbol.to_symbol_code().value) );
       current_supply = t.token_abi_ser.binary_to_variant("currency_stats", data, abi_serializer::create_yield_function(eosio_system_tester::abi_serializer_max_time))["supply"].template as<asset>();
    }
    t.issue( asset((1ll << 62) - 1, core_symbol) - current_supply );
@@ -1745,15 +1745,15 @@ BOOST_AUTO_TEST_CASE(extreme_inflation) try {
    t.produce_block();
 
    t.produce_block(fc::hours(10*24));
-   BOOST_REQUIRE_EQUAL(t.wasm_assert_msg("quantity exceeds available supply"), t.push_action(N(defproducera), N(claimrewards), mvo()("owner", "defproducera")));
+   BOOST_REQUIRE_EQUAL(t.wasm_assert_msg("quantity exceeds available supply"), t.push_action("defproducera"_n, "claimrewards"_n, mvo()("owner", "defproducera")));
 
    t.produce_block(fc::hours(11*24));
-   BOOST_REQUIRE_EQUAL(t.wasm_assert_msg("magnitude of asset amount must be less than 2^62"), t.push_action(N(defproducera), N(claimrewards), mvo()("owner", "defproducera")));
+   BOOST_REQUIRE_EQUAL(t.wasm_assert_msg("magnitude of asset amount must be less than 2^62"), t.push_action("defproducera"_n, "claimrewards"_n, mvo()("owner", "defproducera")));
 
    t.produce_block(fc::hours(24));
-   BOOST_REQUIRE_EQUAL(t.wasm_assert_msg("overflow in calculating new tokens to be issued; inflation rate is too high"), t.push_action(N(defproducera), N(claimrewards), mvo()("owner", "defproducera")));
+   BOOST_REQUIRE_EQUAL(t.wasm_assert_msg("overflow in calculating new tokens to be issued; inflation rate is too high"), t.push_action("defproducera"_n, "claimrewards"_n, mvo()("owner", "defproducera")));
    BOOST_REQUIRE_EQUAL(t.success(), t.setinflation(500, 50000, 40000));
-   BOOST_REQUIRE_EQUAL(t.wasm_assert_msg("quantity exceeds available supply"), t.push_action(N(defproducera), N(claimrewards), mvo()("owner", "defproducera")));
+   BOOST_REQUIRE_EQUAL(t.wasm_assert_msg("quantity exceeds available supply"), t.push_action("defproducera"_n, "claimrewards"_n, mvo()("owner", "defproducera")));
 } FC_LOG_AND_RETHROW()
 
 BOOST_FIXTURE_TEST_CASE(multiple_producer_pay, eosio_system_tester, * boost::unit_test::tolerance(1e-10)) try {
@@ -1764,7 +1764,7 @@ BOOST_FIXTURE_TEST_CASE(multiple_producer_pay, eosio_system_tester, * boost::uni
 
    const asset net = core_sym::from_string("80.0000");
    const asset cpu = core_sym::from_string("80.0000");
-   const std::vector<account_name> voters = { N(producvotera), N(producvoterb), N(producvoterc), N(producvoterd) };
+   const std::vector<account_name> voters = { "producvotera"_n, "producvoterb"_n, "producvoterc"_n, "producvoterd"_n };
    for (const auto& v: voters) {
       create_account_with_resources( v, config::system_account_name, core_sym::from_string("1.0000"), false, net, cpu );
       transfer( config::system_account_name, v, core_sym::from_string("100000000.0000"), config::system_account_name );
@@ -1804,19 +1804,19 @@ BOOST_FIXTURE_TEST_CASE(multiple_producer_pay, eosio_system_tester, * boost::uni
    // producvoterc votes for defproducera ... defproducerz
    // producvoterd votes for abcproducera ... abcproducern
    {
-      BOOST_REQUIRE_EQUAL(success(), vote(N(producvotera), vector<account_name>(producer_names.begin(), producer_names.begin()+10)));
-      BOOST_REQUIRE_EQUAL(success(), vote(N(producvoterb), vector<account_name>(producer_names.begin(), producer_names.begin()+21)));
-      BOOST_REQUIRE_EQUAL(success(), vote(N(producvoterc), vector<account_name>(producer_names.begin(), producer_names.begin()+26)));
-      BOOST_REQUIRE_EQUAL(success(), vote(N(producvoterd), vector<account_name>(producer_names.begin()+26, producer_names.end())));
+      BOOST_REQUIRE_EQUAL(success(), vote("producvotera"_n, vector<account_name>(producer_names.begin(), producer_names.begin()+10)));
+      BOOST_REQUIRE_EQUAL(success(), vote("producvoterb"_n, vector<account_name>(producer_names.begin(), producer_names.begin()+21)));
+      BOOST_REQUIRE_EQUAL(success(), vote("producvoterc"_n, vector<account_name>(producer_names.begin(), producer_names.begin()+26)));
+      BOOST_REQUIRE_EQUAL(success(), vote("producvoterd"_n, vector<account_name>(producer_names.begin()+26, producer_names.end())));
    }
 
    {
-      auto proda = get_producer_info( N(defproducera) );
-      auto prodj = get_producer_info( N(defproducerj) );
-      auto prodk = get_producer_info( N(defproducerk) );
-      auto produ = get_producer_info( N(defproduceru) );
-      auto prodv = get_producer_info( N(defproducerv) );
-      auto prodz = get_producer_info( N(defproducerz) );
+      auto proda = get_producer_info( "defproducera"_n );
+      auto prodj = get_producer_info( "defproducerj"_n );
+      auto prodk = get_producer_info( "defproducerk"_n );
+      auto produ = get_producer_info( "defproduceru"_n );
+      auto prodv = get_producer_info( "defproducerv"_n );
+      auto prodz = get_producer_info( "defproducerz"_n );
 
       BOOST_REQUIRE (0 == proda["unpaid_blocks"].as<uint32_t>() && 0 == prodz["unpaid_blocks"].as<uint32_t>());
 
@@ -1870,25 +1870,25 @@ BOOST_FIXTURE_TEST_CASE(multiple_producer_pay, eosio_system_tester, * boost::uni
       const uint64_t initial_claim_time        = microseconds_since_epoch_of_iso_string( initial_global_state["last_pervote_bucket_fill"] );
       const int64_t  initial_pervote_bucket    = initial_global_state["pervote_bucket"].as<int64_t>();
       const int64_t  initial_perblock_bucket   = initial_global_state["perblock_bucket"].as<int64_t>();
-      const int64_t  initial_savings           = get_balance(N(eosio.saving)).get_amount();
+      const int64_t  initial_savings           = get_balance("eosio.saving"_n).get_amount();
       const uint32_t initial_tot_unpaid_blocks = initial_global_state["total_unpaid_blocks"].as<uint32_t>();
       const asset    initial_supply            = get_token_supply();
-      const asset    initial_bpay_balance      = get_balance(N(eosio.bpay));
-      const asset    initial_vpay_balance      = get_balance(N(eosio.vpay));
+      const asset    initial_bpay_balance      = get_balance("eosio.bpay"_n);
+      const asset    initial_vpay_balance      = get_balance("eosio.vpay"_n);
       const asset    initial_balance           = get_balance(prod_name);
       const uint32_t initial_unpaid_blocks     = get_producer_info(prod_name)["unpaid_blocks"].as<uint32_t>();
 
-      BOOST_REQUIRE_EQUAL(success(), push_action(prod_name, N(claimrewards), mvo()("owner", prod_name)));
+      BOOST_REQUIRE_EQUAL(success(), push_action(prod_name, "claimrewards"_n, mvo()("owner", prod_name)));
 
       const auto     global_state      = get_global_state();
       const uint64_t claim_time        = microseconds_since_epoch_of_iso_string( global_state["last_pervote_bucket_fill"] );
       const int64_t  pervote_bucket    = global_state["pervote_bucket"].as<int64_t>();
       const int64_t  perblock_bucket   = global_state["perblock_bucket"].as<int64_t>();
-      const int64_t  savings           = get_balance(N(eosio.saving)).get_amount();
+      const int64_t  savings           = get_balance("eosio.saving"_n).get_amount();
       const uint32_t tot_unpaid_blocks = global_state["total_unpaid_blocks"].as<uint32_t>();
       const asset    supply            = get_token_supply();
-      const asset    bpay_balance      = get_balance(N(eosio.bpay));
-      const asset    vpay_balance      = get_balance(N(eosio.vpay));
+      const asset    bpay_balance      = get_balance("eosio.bpay"_n);
+      const asset    vpay_balance      = get_balance("eosio.vpay"_n);
       const asset    balance           = get_balance(prod_name);
       const uint32_t unpaid_blocks     = get_producer_info(prod_name)["unpaid_blocks"].as<uint32_t>();
 
@@ -1921,17 +1921,17 @@ BOOST_FIXTURE_TEST_CASE(multiple_producer_pay, eosio_system_tester, * boost::uni
       produce_blocks(5);
 
       BOOST_REQUIRE_EQUAL(wasm_assert_msg("already claimed rewards within past day"),
-                          push_action(prod_name, N(claimrewards), mvo()("owner", prod_name)));
+                          push_action(prod_name, "claimrewards"_n, mvo()("owner", prod_name)));
    }
 
    {
       const uint32_t prod_index = 23;
       const auto prod_name = producer_names[prod_index];
       BOOST_REQUIRE_EQUAL(success(),
-                          push_action(prod_name, N(claimrewards), mvo()("owner", prod_name)));
+                          push_action(prod_name, "claimrewards"_n, mvo()("owner", prod_name)));
       BOOST_REQUIRE_EQUAL(0, get_balance(prod_name).get_amount());
       BOOST_REQUIRE_EQUAL(wasm_assert_msg("already claimed rewards within past day"),
-                          push_action(prod_name, N(claimrewards), mvo()("owner", prod_name)));
+                          push_action(prod_name, "claimrewards"_n, mvo()("owner", prod_name)));
    }
 
    // Wait for 23 hours. By now, pervote_bucket has grown enough
@@ -1946,25 +1946,25 @@ BOOST_FIXTURE_TEST_CASE(multiple_producer_pay, eosio_system_tester, * boost::uni
       const uint64_t initial_claim_time        = microseconds_since_epoch_of_iso_string( initial_global_state["last_pervote_bucket_fill"] );
       const int64_t  initial_pervote_bucket    = initial_global_state["pervote_bucket"].as<int64_t>();
       const int64_t  initial_perblock_bucket   = initial_global_state["perblock_bucket"].as<int64_t>();
-      const int64_t  initial_savings           = get_balance(N(eosio.saving)).get_amount();
+      const int64_t  initial_savings           = get_balance("eosio.saving"_n).get_amount();
       const uint32_t initial_tot_unpaid_blocks = initial_global_state["total_unpaid_blocks"].as<uint32_t>();
       const asset    initial_supply            = get_token_supply();
-      const asset    initial_bpay_balance      = get_balance(N(eosio.bpay));
-      const asset    initial_vpay_balance      = get_balance(N(eosio.vpay));
+      const asset    initial_bpay_balance      = get_balance("eosio.bpay"_n);
+      const asset    initial_vpay_balance      = get_balance("eosio.vpay"_n);
       const asset    initial_balance           = get_balance(prod_name);
       const uint32_t initial_unpaid_blocks     = get_producer_info(prod_name)["unpaid_blocks"].as<uint32_t>();
 
-      BOOST_REQUIRE_EQUAL(success(), push_action(prod_name, N(claimrewards), mvo()("owner", prod_name)));
+      BOOST_REQUIRE_EQUAL(success(), push_action(prod_name, "claimrewards"_n, mvo()("owner", prod_name)));
 
       const auto     global_state      = get_global_state();
       const uint64_t claim_time        = microseconds_since_epoch_of_iso_string( global_state["last_pervote_bucket_fill"] );
       const int64_t  pervote_bucket    = global_state["pervote_bucket"].as<int64_t>();
       const int64_t  perblock_bucket   = global_state["perblock_bucket"].as<int64_t>();
-      const int64_t  savings           = get_balance(N(eosio.saving)).get_amount();
+      const int64_t  savings           = get_balance("eosio.saving"_n).get_amount();
       const uint32_t tot_unpaid_blocks = global_state["total_unpaid_blocks"].as<uint32_t>();
       const asset    supply            = get_token_supply();
-      const asset    bpay_balance      = get_balance(N(eosio.bpay));
-      const asset    vpay_balance      = get_balance(N(eosio.vpay));
+      const asset    bpay_balance      = get_balance("eosio.bpay"_n);
+      const asset    vpay_balance      = get_balance("eosio.vpay"_n);
       const asset    balance           = get_balance(prod_name);
       const uint32_t unpaid_blocks     = get_producer_info(prod_name)["unpaid_blocks"].as<uint32_t>();
 
@@ -1996,17 +1996,17 @@ BOOST_FIXTURE_TEST_CASE(multiple_producer_pay, eosio_system_tester, * boost::uni
       produce_blocks(5);
 
       BOOST_REQUIRE_EQUAL(wasm_assert_msg("already claimed rewards within past day"),
-                          push_action(prod_name, N(claimrewards), mvo()("owner", prod_name)));
+                          push_action(prod_name, "claimrewards"_n, mvo()("owner", prod_name)));
    }
 
    {
       const uint32_t prod_index = 24;
       const auto prod_name = producer_names[prod_index];
       BOOST_REQUIRE_EQUAL(success(),
-                          push_action(prod_name, N(claimrewards), mvo()("owner", prod_name)));
+                          push_action(prod_name, "claimrewards"_n, mvo()("owner", prod_name)));
       BOOST_REQUIRE(100 * 10000 <= get_balance(prod_name).get_amount());
       BOOST_REQUIRE_EQUAL(wasm_assert_msg("already claimed rewards within past day"),
-                          push_action(prod_name, N(claimrewards), mvo()("owner", prod_name)));
+                          push_action(prod_name, "claimrewards"_n, mvo()("owner", prod_name)));
    }
 
    {
@@ -2018,11 +2018,11 @@ BOOST_FIXTURE_TEST_CASE(multiple_producer_pay, eosio_system_tester, * boost::uni
       BOOST_REQUIRE( fc::crypto::public_key() != fc::crypto::public_key(info["producer_key"].as_string()) );
 
       BOOST_REQUIRE_EQUAL( error("missing authority of eosio"),
-                           push_action(prod_name, N(rmvproducer), mvo()("producer", prod_name)));
+                           push_action(prod_name, "rmvproducer"_n, mvo()("producer", prod_name)));
       BOOST_REQUIRE_EQUAL( error("missing authority of eosio"),
-                           push_action(producer_names[rmv_index + 2], N(rmvproducer), mvo()("producer", prod_name) ) );
+                           push_action(producer_names[rmv_index + 2], "rmvproducer"_n, mvo()("producer", prod_name) ) );
       BOOST_REQUIRE_EQUAL( success(),
-                           push_action(config::system_account_name, N(rmvproducer), mvo()("producer", prod_name) ) );
+                           push_action(config::system_account_name, "rmvproducer"_n, mvo()("producer", prod_name) ) );
       {
          bool rest_didnt_produce = true;
          for (uint32_t i = 21; i < producer_names.size(); ++i) {
@@ -2039,7 +2039,7 @@ BOOST_FIXTURE_TEST_CASE(multiple_producer_pay, eosio_system_tester, * boost::uni
       BOOST_REQUIRE( !info["is_active"].as<bool>() );
       BOOST_REQUIRE( fc::crypto::public_key() == fc::crypto::public_key(info["producer_key"].as_string()) );
       BOOST_REQUIRE_EQUAL( wasm_assert_msg("producer does not have an active key"),
-                           push_action(prod_name, N(claimrewards), mvo()("owner", prod_name) ) );
+                           push_action(prod_name, "claimrewards"_n, mvo()("owner", prod_name) ) );
       produce_blocks(3 * 21 * 12);
       BOOST_REQUIRE_EQUAL( init_unpaid_blocks, get_producer_info(prod_name)["unpaid_blocks"].as<uint32_t>() );
       {
@@ -2055,7 +2055,7 @@ BOOST_FIXTURE_TEST_CASE(multiple_producer_pay, eosio_system_tester, * boost::uni
 
    {
       BOOST_REQUIRE_EQUAL( wasm_assert_msg("producer not found"),
-                           push_action( config::system_account_name, N(rmvproducer), mvo()("producer", "nonexistingp") ) );
+                           push_action( config::system_account_name, "rmvproducer"_n, mvo()("producer", "nonexistingp") ) );
    }
 
    produce_block(fc::hours(24));
@@ -2064,9 +2064,9 @@ BOOST_FIXTURE_TEST_CASE(multiple_producer_pay, eosio_system_tester, * boost::uni
    {
       BOOST_REQUIRE_EQUAL( 0, get_global_state2()["revision"].as<uint8_t>() );
       BOOST_REQUIRE_EQUAL( error("missing authority of eosio"),
-                           push_action(producer_names[1], N(updtrevision), mvo()("revision", 1) ) );
+                           push_action(producer_names[1], "updtrevision"_n, mvo()("revision", 1) ) );
       BOOST_REQUIRE_EQUAL( success(),
-                           push_action(config::system_account_name, N(updtrevision), mvo()("revision", 1) ) );
+                           push_action(config::system_account_name, "updtrevision"_n, mvo()("revision", 1) ) );
       BOOST_REQUIRE_EQUAL( 1, get_global_state2()["revision"].as<uint8_t>() );
 
       const uint32_t prod_index = 2;
@@ -2089,7 +2089,7 @@ BOOST_FIXTURE_TEST_CASE(multiple_producer_pay, eosio_system_tester, * boost::uni
       const uint64_t initial_prod_update_time  = microseconds_since_epoch_of_iso_string( initial_prod_info2["last_votepay_share_update"] );
 
       BOOST_TEST_REQUIRE( 0 == get_producer_info2(prod_name)["votepay_share"].as_double() );
-      BOOST_REQUIRE_EQUAL( success(), push_action(prod_name, N(claimrewards), mvo()("owner", prod_name) ) );
+      BOOST_REQUIRE_EQUAL( success(), push_action(prod_name, "claimrewards"_n, mvo()("owner", prod_name) ) );
 
       const auto     prod_info         = get_producer_info(prod_name);
       const auto     prod_info2        = get_producer_info2(prod_name);
@@ -2129,7 +2129,7 @@ BOOST_FIXTURE_TEST_CASE(multiple_producer_pay, eosio_system_tester, * boost::uni
       produce_block(fc::hours(2));
 
       BOOST_REQUIRE_EQUAL( wasm_assert_msg("already claimed rewards within past day"),
-                           push_action(prod_name, N(claimrewards), mvo()("owner", prod_name) ) );
+                           push_action(prod_name, "claimrewards"_n, mvo()("owner", prod_name) ) );
    }
 
 } FC_LOG_AND_RETHROW()
@@ -2139,7 +2139,7 @@ BOOST_FIXTURE_TEST_CASE(multiple_producer_votepay_share, eosio_system_tester, * 
 
    const asset net = core_sym::from_string("80.0000");
    const asset cpu = core_sym::from_string("80.0000");
-   const std::vector<account_name> voters = { N(producvotera), N(producvoterb), N(producvoterc), N(producvoterd) };
+   const std::vector<account_name> voters = { "producvotera"_n, "producvoterb"_n, "producvoterc"_n, "producvoterd"_n };
    for (const auto& v: voters) {
       create_account_with_resources( v, config::system_account_name, core_sym::from_string("1.0000"), false, net, cpu );
       transfer( config::system_account_name, v, core_sym::from_string("100000000.0000"), config::system_account_name );
@@ -2182,14 +2182,14 @@ BOOST_FIXTURE_TEST_CASE(multiple_producer_votepay_share, eosio_system_tester, * 
    // producvoterd votes for abcproducera ... abcproducern
    {
       BOOST_TEST_REQUIRE( 0 == get_global_state3()["total_vpay_share_change_rate"].as_double() );
-      BOOST_REQUIRE_EQUAL( success(), vote(N(producvotera), vector<account_name>(producer_names.begin(), producer_names.begin()+10)) );
+      BOOST_REQUIRE_EQUAL( success(), vote("producvotera"_n, vector<account_name>(producer_names.begin(), producer_names.begin()+10)) );
       produce_block( fc::hours(10) );
       BOOST_TEST_REQUIRE( 0 == get_global_state2()["total_producer_votepay_share"].as_double() );
       const auto& init_info  = get_producer_info(producer_names[0]);
       const auto& init_info2 = get_producer_info2(producer_names[0]);
       uint64_t init_update = microseconds_since_epoch_of_iso_string( init_info2["last_votepay_share_update"] );
       double   init_votes  = init_info["total_votes"].as_double();
-      BOOST_REQUIRE_EQUAL( success(), vote(N(producvoterb), vector<account_name>(producer_names.begin(), producer_names.begin()+21)) );
+      BOOST_REQUIRE_EQUAL( success(), vote("producvoterb"_n, vector<account_name>(producer_names.begin(), producer_names.begin()+21)) );
       const auto& info  = get_producer_info(producer_names[0]);
       const auto& info2 = get_producer_info2(producer_names[0]);
       BOOST_TEST_REQUIRE( ((microseconds_since_epoch_of_iso_string( info2["last_votepay_share_update"] ) - init_update)/double(1E6)) * init_votes == info2["votepay_share"].as_double() );
@@ -2197,20 +2197,20 @@ BOOST_FIXTURE_TEST_CASE(multiple_producer_votepay_share, eosio_system_tester, * 
 
       BOOST_TEST_REQUIRE( 0 == get_producer_info2(producer_names[11])["votepay_share"].as_double() );
       produce_block( fc::hours(13) );
-      BOOST_REQUIRE_EQUAL( success(), vote(N(producvoterc), vector<account_name>(producer_names.begin(), producer_names.begin()+26)) );
+      BOOST_REQUIRE_EQUAL( success(), vote("producvoterc"_n, vector<account_name>(producer_names.begin(), producer_names.begin()+26)) );
       BOOST_REQUIRE( 0 < get_producer_info2(producer_names[11])["votepay_share"].as_double() );
       produce_block( fc::hours(1) );
-      BOOST_REQUIRE_EQUAL( success(), vote(N(producvoterd), vector<account_name>(producer_names.begin()+26, producer_names.end())) );
+      BOOST_REQUIRE_EQUAL( success(), vote("producvoterd"_n, vector<account_name>(producer_names.begin()+26, producer_names.end())) );
       BOOST_TEST_REQUIRE( 0 == get_producer_info2(producer_names[26])["votepay_share"].as_double() );
    }
 
    {
-      auto proda = get_producer_info( N(defproducera) );
-      auto prodj = get_producer_info( N(defproducerj) );
-      auto prodk = get_producer_info( N(defproducerk) );
-      auto produ = get_producer_info( N(defproduceru) );
-      auto prodv = get_producer_info( N(defproducerv) );
-      auto prodz = get_producer_info( N(defproducerz) );
+      auto proda = get_producer_info( "defproducera"_n );
+      auto prodj = get_producer_info( "defproducerj"_n );
+      auto prodk = get_producer_info( "defproducerk"_n );
+      auto produ = get_producer_info( "defproduceru"_n );
+      auto prodv = get_producer_info( "defproducerv"_n );
+      auto prodz = get_producer_info( "defproducerz"_n );
 
       BOOST_REQUIRE (0 == proda["unpaid_blocks"].as<uint32_t>() && 0 == prodz["unpaid_blocks"].as<uint32_t>());
 
@@ -2269,7 +2269,7 @@ BOOST_FIXTURE_TEST_CASE(multiple_producer_votepay_share, eosio_system_tester, * 
       BOOST_REQUIRE( 0 < init_info2["votepay_share"].as_double() );
       BOOST_REQUIRE( 0 < microseconds_since_epoch_of_iso_string( init_info2["last_votepay_share_update"] ) );
 
-      BOOST_REQUIRE_EQUAL( success(), push_action(prod_name, N(claimrewards), mvo()("owner", prod_name)) );
+      BOOST_REQUIRE_EQUAL( success(), push_action(prod_name, "claimrewards"_n, mvo()("owner", prod_name)) );
 
       BOOST_TEST_REQUIRE( 0 == get_producer_info2(prod_name)["votepay_share"].as_double() );
       BOOST_REQUIRE_EQUAL( get_producer_info(prod_name)["last_claim_time"].as_string(),
@@ -2298,7 +2298,7 @@ BOOST_FIXTURE_TEST_CASE(votepay_share_invariant, eosio_system_tester, * boost::u
 
    const asset net = core_sym::from_string("80.0000");
    const asset cpu = core_sym::from_string("80.0000");
-   const std::vector<account_name> accounts = { N(aliceaccount), N(bobbyaccount), N(carolaccount), N(emilyaccount) };
+   const std::vector<account_name> accounts = { "aliceaccount"_n, "bobbyaccount"_n, "carolaccount"_n, "emilyaccount"_n };
    for (const auto& a: accounts) {
       create_account_with_resources( a, config::system_account_name, core_sym::from_string("1.0000"), false, net, cpu );
       transfer( config::system_account_name, a, core_sym::from_string("1000.0000"), config::system_account_name );
@@ -2324,7 +2324,7 @@ BOOST_FIXTURE_TEST_CASE(votepay_share_invariant, eosio_system_tester, * boost::u
 
    produce_block( fc::hours(1) );
 
-   BOOST_REQUIRE_EQUAL( success(), push_action(proda, N(claimrewards), mvo()("owner", proda)) );
+   BOOST_REQUIRE_EQUAL( success(), push_action(proda, "claimrewards"_n, mvo()("owner", proda)) );
    BOOST_TEST_REQUIRE( 0 == get_producer_info2(proda)["votepay_share"].as_double() );
 
    produce_block( fc::hours(24) );
@@ -2333,7 +2333,7 @@ BOOST_FIXTURE_TEST_CASE(votepay_share_invariant, eosio_system_tester, * boost::u
 
    produce_block( fc::hours(24) );
 
-   BOOST_REQUIRE_EQUAL( success(), push_action(prodb, N(claimrewards), mvo()("owner", prodb)) );
+   BOOST_REQUIRE_EQUAL( success(), push_action(prodb, "claimrewards"_n, mvo()("owner", prodb)) );
    BOOST_TEST_REQUIRE( 0 == get_producer_info2(prodb)["votepay_share"].as_double() );
 
    produce_block( fc::hours(10) );
@@ -2366,7 +2366,7 @@ BOOST_FIXTURE_TEST_CASE(votepay_share_proxy, eosio_system_tester, * boost::unit_
 
    const asset net = core_sym::from_string("80.0000");
    const asset cpu = core_sym::from_string("80.0000");
-   const std::vector<account_name> accounts = { N(aliceaccount), N(bobbyaccount), N(carolaccount), N(emilyaccount) };
+   const std::vector<account_name> accounts = { "aliceaccount"_n, "bobbyaccount"_n, "carolaccount"_n, "emilyaccount"_n };
    for (const auto& a: accounts) {
       create_account_with_resources( a, config::system_account_name, core_sym::from_string("1.0000"), false, net, cpu );
       transfer( config::system_account_name, a, core_sym::from_string("1000.0000"), config::system_account_name );
@@ -2377,7 +2377,7 @@ BOOST_FIXTURE_TEST_CASE(votepay_share_proxy, eosio_system_tester, * boost::unit_
    const auto emily = accounts[3];
 
    // alice becomes a proxy
-   BOOST_REQUIRE_EQUAL( success(), push_action( alice, N(regproxy), mvo()("proxy", alice)("isproxy", true) ) );
+   BOOST_REQUIRE_EQUAL( success(), push_action( alice, "regproxy"_n, mvo()("proxy", alice)("isproxy", true) ) );
    REQUIRE_MATCHING_OBJECT( proxy( alice ), get_voter_info( alice ) );
 
    // carol and emily become producers
@@ -2423,7 +2423,7 @@ BOOST_FIXTURE_TEST_CASE(votepay_share_proxy, eosio_system_tester, * boost::unit_
    total_votes      = get_producer_info(carol)["total_votes"].as_double();
 
    // carol claims rewards
-   BOOST_REQUIRE_EQUAL( success(), push_action(carol, N(claimrewards), mvo()("owner", carol)) );
+   BOOST_REQUIRE_EQUAL( success(), push_action(carol, "claimrewards"_n, mvo()("owner", carol)) );
 
    produce_block( fc::hours(20) );
 
@@ -2461,7 +2461,7 @@ BOOST_FIXTURE_TEST_CASE(votepay_share_proxy, eosio_system_tester, * boost::unit_
    produce_block( fc::hours(24) );
 
    // carol finally claims rewards
-   BOOST_REQUIRE_EQUAL( success(), push_action( carol, N(claimrewards), mvo()("owner", carol) ) );
+   BOOST_REQUIRE_EQUAL( success(), push_action( carol, "claimrewards"_n, mvo()("owner", carol) ) );
    BOOST_TEST_REQUIRE( 0           == get_producer_info2(carol)["votepay_share"].as_double() );
    BOOST_TEST_REQUIRE( 0           == get_global_state2()["total_producer_votepay_share"].as_double() );
    BOOST_TEST_REQUIRE( total_votes == get_global_state3()["total_vpay_share_change_rate"].as_double() );
@@ -2514,7 +2514,7 @@ BOOST_FIXTURE_TEST_CASE(votepay_share_update_order, eosio_system_tester, * boost
 
    const asset net = core_sym::from_string("80.0000");
    const asset cpu = core_sym::from_string("80.0000");
-   const std::vector<account_name> accounts = { N(aliceaccount), N(bobbyaccount), N(carolaccount), N(emilyaccount) };
+   const std::vector<account_name> accounts = { "aliceaccount"_n, "bobbyaccount"_n, "carolaccount"_n, "emilyaccount"_n };
    for (const auto& a: accounts) {
       create_account_with_resources( a, config::system_account_name, core_sym::from_string("1.0000"), false, net, cpu );
       transfer( config::system_account_name, a, core_sym::from_string("1000.0000"), config::system_account_name );
@@ -2535,9 +2535,9 @@ BOOST_FIXTURE_TEST_CASE(votepay_share_update_order, eosio_system_tester, * boost
    BOOST_REQUIRE_EQUAL( success(), vote( alice, { carol, emily } ) );
 
 
-   BOOST_REQUIRE_EQUAL( success(), push_action( carol, N(claimrewards), mvo()("owner", carol) ) );
+   BOOST_REQUIRE_EQUAL( success(), push_action( carol, "claimrewards"_n, mvo()("owner", carol) ) );
    produce_block( fc::hours(1) );
-   BOOST_REQUIRE_EQUAL( success(), push_action( emily, N(claimrewards), mvo()("owner", emily) ) );
+   BOOST_REQUIRE_EQUAL( success(), push_action( emily, "claimrewards"_n, mvo()("owner", emily) ) );
 
    produce_block( fc::hours(3 * 24 + 1) );
 
@@ -2545,14 +2545,14 @@ BOOST_FIXTURE_TEST_CASE(votepay_share_update_order, eosio_system_tester, * boost
       signed_transaction trx;
       set_transaction_headers(trx);
 
-      trx.actions.emplace_back( get_action( config::system_account_name, N(claimrewards), { {carol, config::active_name} },
+      trx.actions.emplace_back( get_action( config::system_account_name, "claimrewards"_n, { {carol, config::active_name} },
                                             mvo()("owner", carol) ) );
 
       std::vector<account_name> prods = { carol, emily };
-      trx.actions.emplace_back( get_action( config::system_account_name, N(voteproducer), { {alice, config::active_name} },
+      trx.actions.emplace_back( get_action( config::system_account_name, "voteproducer"_n, { {alice, config::active_name} },
                                             mvo()("voter", alice)("proxy", name(0))("producers", prods) ) );
 
-      trx.actions.emplace_back( get_action( config::system_account_name, N(claimrewards), { {emily, config::active_name} },
+      trx.actions.emplace_back( get_action( config::system_account_name, "claimrewards"_n, { {emily, config::active_name} },
                                             mvo()("owner", emily) ) );
 
       trx.sign( get_private_key( carol, "active" ), control->get_chain_id() );
@@ -2581,7 +2581,7 @@ BOOST_FIXTURE_TEST_CASE(votepay_transition, eosio_system_tester, * boost::unit_t
 
    const asset net = core_sym::from_string("80.0000");
    const asset cpu = core_sym::from_string("80.0000");
-   const std::vector<account_name> voters = { N(producvotera), N(producvoterb), N(producvoterc), N(producvoterd) };
+   const std::vector<account_name> voters = { "producvotera"_n, "producvoterb"_n, "producvoterc"_n, "producvoterd"_n };
    for (const auto& v: voters) {
       create_account_with_resources( v, config::system_account_name, core_sym::from_string("1.0000"), false, net, cpu );
       transfer( config::system_account_name, v, core_sym::from_string("100000000.0000"), config::system_account_name );
@@ -2607,11 +2607,11 @@ BOOST_FIXTURE_TEST_CASE(votepay_transition, eosio_system_tester, * boost::unit_t
       }
    }
 
-   BOOST_REQUIRE_EQUAL( success(), vote(N(producvotera), vector<account_name>(producer_names.begin(), producer_names.end())) );
+   BOOST_REQUIRE_EQUAL( success(), vote("producvotera"_n, vector<account_name>(producer_names.begin(), producer_names.end())) );
    auto* tbl = control->db().find<eosio::chain::table_id_object, eosio::chain::by_code_scope_table>(
                   boost::make_tuple( config::system_account_name,
                                      config::system_account_name,
-                                     N(producers2) ) );
+                                     "producers2"_n ) );
    BOOST_REQUIRE( tbl );
    BOOST_REQUIRE( 0 < microseconds_since_epoch_of_iso_string( get_producer_info2("defproducera")["last_votepay_share_update"] ) );
 
@@ -2620,23 +2620,23 @@ BOOST_FIXTURE_TEST_CASE(votepay_transition, eosio_system_tester, * boost::unit_t
    tbl = control->db().find<eosio::chain::table_id_object, eosio::chain::by_code_scope_table>(
                   boost::make_tuple( config::system_account_name,
                                      config::system_account_name,
-                                     N(producers2) ) );
+                                     "producers2"_n ) );
    BOOST_REQUIRE( !tbl );
 
-   BOOST_REQUIRE_EQUAL( success(), vote(N(producvoterb), vector<account_name>(producer_names.begin(), producer_names.end())) );
+   BOOST_REQUIRE_EQUAL( success(), vote("producvoterb"_n, vector<account_name>(producer_names.begin(), producer_names.end())) );
    tbl = control->db().find<eosio::chain::table_id_object, eosio::chain::by_code_scope_table>(
             boost::make_tuple( config::system_account_name,
                                config::system_account_name,
-                               N(producers2) ) );
+                               "producers2"_n ) );
    BOOST_REQUIRE( !tbl );
-   BOOST_REQUIRE_EQUAL( success(), regproducer(N(defproducera)) );
-   BOOST_REQUIRE( microseconds_since_epoch_of_iso_string( get_producer_info(N(defproducera))["last_claim_time"] ) < microseconds_since_epoch_of_iso_string( get_producer_info2(N(defproducera))["last_votepay_share_update"] ) );
+   BOOST_REQUIRE_EQUAL( success(), regproducer("defproducera"_n) );
+   BOOST_REQUIRE( microseconds_since_epoch_of_iso_string( get_producer_info("defproducera"_n)["last_claim_time"] ) < microseconds_since_epoch_of_iso_string( get_producer_info2("defproducera"_n)["last_votepay_share_update"] ) );
 
-   create_account_with_resources( N(defproducer1), config::system_account_name, core_sym::from_string("1.0000"), false, net, cpu );
-   BOOST_REQUIRE_EQUAL( success(), regproducer(N(defproducer1)) );
-   BOOST_REQUIRE( 0 < microseconds_since_epoch_of_iso_string( get_producer_info(N(defproducer1))["last_claim_time"] ) );
-   BOOST_REQUIRE_EQUAL( get_producer_info(N(defproducer1))["last_claim_time"].as_string(),
-                        get_producer_info2(N(defproducer1))["last_votepay_share_update"].as_string() );
+   create_account_with_resources( "defproducer1"_n, config::system_account_name, core_sym::from_string("1.0000"), false, net, cpu );
+   BOOST_REQUIRE_EQUAL( success(), regproducer("defproducer1"_n) );
+   BOOST_REQUIRE( 0 < microseconds_since_epoch_of_iso_string( get_producer_info("defproducer1"_n)["last_claim_time"] ) );
+   BOOST_REQUIRE_EQUAL( get_producer_info("defproducer1"_n)["last_claim_time"].as_string(),
+                        get_producer_info2("defproducer1"_n)["last_votepay_share_update"].as_string() );
 
 } FC_LOG_AND_RETHROW()
 
@@ -2662,7 +2662,7 @@ BOOST_AUTO_TEST_CASE(votepay_transition2, * boost::unit_test::tolerance(1e-10)) 
    }
    const asset net = old_core_from_string("80.0000");
    const asset cpu = old_core_from_string("80.0000");
-   const std::vector<account_name> voters = { N(producvotera), N(producvoterb), N(producvoterc), N(producvoterd) };
+   const std::vector<account_name> voters = { "producvotera"_n, "producvoterb"_n, "producvoterc"_n, "producvoterd"_n };
    for (const auto& v: voters) {
       t.create_account_with_resources( v, config::system_account_name, old_core_from_string("1.0000"), false, net, cpu );
       t.transfer( config::system_account_name, v, old_core_from_string("100000000.0000"), config::system_account_name );
@@ -2687,17 +2687,17 @@ BOOST_AUTO_TEST_CASE(votepay_transition2, * boost::unit_test::tolerance(1e-10)) 
       }
    }
 
-   BOOST_REQUIRE_EQUAL( t.success(), t.vote(N(producvotera), vector<account_name>(producer_names.begin(), producer_names.end())) );
+   BOOST_REQUIRE_EQUAL( t.success(), t.vote("producvotera"_n, vector<account_name>(producer_names.begin(), producer_names.end())) );
    t.produce_block( fc::hours(20) );
-   BOOST_REQUIRE_EQUAL( t.success(), t.vote(N(producvoterb), vector<account_name>(producer_names.begin(), producer_names.end())) );
+   BOOST_REQUIRE_EQUAL( t.success(), t.vote("producvoterb"_n, vector<account_name>(producer_names.begin(), producer_names.end())) );
    t.produce_block( fc::hours(30) );
-   BOOST_REQUIRE_EQUAL( t.success(), t.vote(N(producvoterc), vector<account_name>(producer_names.begin(), producer_names.end())) );
-   BOOST_REQUIRE_EQUAL( t.success(), t.push_action(producer_names[0], N(claimrewards), mvo()("owner", producer_names[0])) );
-   BOOST_REQUIRE_EQUAL( t.success(), t.push_action(producer_names[1], N(claimrewards), mvo()("owner", producer_names[1])) );
+   BOOST_REQUIRE_EQUAL( t.success(), t.vote("producvoterc"_n, vector<account_name>(producer_names.begin(), producer_names.end())) );
+   BOOST_REQUIRE_EQUAL( t.success(), t.push_action(producer_names[0], "claimrewards"_n, mvo()("owner", producer_names[0])) );
+   BOOST_REQUIRE_EQUAL( t.success(), t.push_action(producer_names[1], "claimrewards"_n, mvo()("owner", producer_names[1])) );
    auto* tbl = t.control->db().find<eosio::chain::table_id_object, eosio::chain::by_code_scope_table>(
                                     boost::make_tuple( config::system_account_name,
                                                        config::system_account_name,
-                                                       N(producers2) ) );
+                                                       "producers2"_n ) );
    BOOST_REQUIRE( !tbl );
 
    t.produce_block( fc::hours(2*24) );
@@ -2707,7 +2707,7 @@ BOOST_AUTO_TEST_CASE(votepay_transition2, * boost::unit_test::tolerance(1e-10)) 
    t.produce_blocks(2);
    t.produce_block( fc::hours(24 + 1) );
 
-   BOOST_REQUIRE_EQUAL( t.success(), t.push_action(producer_names[0], N(claimrewards), mvo()("owner", producer_names[0])) );
+   BOOST_REQUIRE_EQUAL( t.success(), t.push_action(producer_names[0], "claimrewards"_n, mvo()("owner", producer_names[0])) );
    BOOST_TEST_REQUIRE( 0 == t.get_global_state2()["total_producer_votepay_share"].as_double() );
    BOOST_TEST_REQUIRE( t.get_producer_info(producer_names[0])["total_votes"].as_double() == t.get_global_state3()["total_vpay_share_change_rate"].as_double() );
 
@@ -2730,11 +2730,11 @@ BOOST_FIXTURE_TEST_CASE(producers_upgrade_system_contract, eosio_system_tester) 
          string action_type_name = msig_abi_ser.get_action_type(name);
 
          action act;
-         act.account = N(eosio.msig);
+         act.account = "eosio.msig"_n;
          act.name = name;
          act.data = msig_abi_ser.variant_to_binary( action_type_name, data, abi_serializer::create_yield_function(abi_serializer_max_time) );
 
-         return base_tester::push_action( std::move(act), (auth ? signer : signer == N(bob111111111) ? N(alice1111111) : N(bob111111111)).to_uint64_t() );
+         return base_tester::push_action( std::move(act), (auth ? signer : signer == "bob111111111"_n ? "alice1111111"_n : "bob111111111"_n).to_uint64_t() );
    };
    // test begins
    vector<permission_level> prod_perms;
@@ -2752,7 +2752,7 @@ BOOST_FIXTURE_TEST_CASE(producers_upgrade_system_contract, eosio_system_tester) 
       msg[0] = 'P';
       std::copy( msg.begin(), msg.end(), it );
 
-      variant pretty_trx = fc::mutable_variant_object()
+      fc::variant pretty_trx = fc::mutable_variant_object()
          ("expiration", "2020-01-01T00:30")
          ("ref_block_num", 2)
          ("ref_block_prefix", 3)
@@ -2774,7 +2774,7 @@ BOOST_FIXTURE_TEST_CASE(producers_upgrade_system_contract, eosio_system_tester) 
       abi_serializer::from_variant(pretty_trx, trx, get_resolver(), abi_serializer::create_yield_function(abi_serializer_max_time));
    }
 
-   BOOST_REQUIRE_EQUAL(success(), push_action_msig( N(alice1111111), N(propose), mvo()
+   BOOST_REQUIRE_EQUAL(success(), push_action_msig( "alice1111111"_n, "propose"_n, mvo()
                                                     ("proposer",      "alice1111111")
                                                     ("proposal_name", "upgrade1")
                                                     ("trx",           trx)
@@ -2784,7 +2784,7 @@ BOOST_FIXTURE_TEST_CASE(producers_upgrade_system_contract, eosio_system_tester) 
 
    // get 15 approvals
    for ( size_t i = 0; i < 14; ++i ) {
-      BOOST_REQUIRE_EQUAL(success(), push_action_msig( name(producer_names[i]), N(approve), mvo()
+      BOOST_REQUIRE_EQUAL(success(), push_action_msig( name(producer_names[i]), "approve"_n, mvo()
                                                        ("proposer",      "alice1111111")
                                                        ("proposal_name", "upgrade1")
                                                        ("level",         permission_level{ name(producer_names[i]), config::active_name })
@@ -2794,7 +2794,7 @@ BOOST_FIXTURE_TEST_CASE(producers_upgrade_system_contract, eosio_system_tester) 
 
    //should fail
    BOOST_REQUIRE_EQUAL(wasm_assert_msg("transaction authorization failed"),
-                       push_action_msig( N(alice1111111), N(exec), mvo()
+                       push_action_msig( "alice1111111"_n, "exec"_n, mvo()
                                          ("proposer",      "alice1111111")
                                          ("proposal_name", "upgrade1")
                                          ("executer",      "alice1111111")
@@ -2802,7 +2802,7 @@ BOOST_FIXTURE_TEST_CASE(producers_upgrade_system_contract, eosio_system_tester) 
    );
 
    // one more approval
-   BOOST_REQUIRE_EQUAL(success(), push_action_msig( name(producer_names[14]), N(approve), mvo()
+   BOOST_REQUIRE_EQUAL(success(), push_action_msig( name(producer_names[14]), "approve"_n, mvo()
                                                     ("proposer",      "alice1111111")
                                                     ("proposal_name", "upgrade1")
                                                     ("level",         permission_level{ name(producer_names[14]), config::active_name })
@@ -2816,7 +2816,7 @@ BOOST_FIXTURE_TEST_CASE(producers_upgrade_system_contract, eosio_system_tester) 
       if( t->scheduled ) { trace = t; }
    } );
 
-   BOOST_REQUIRE_EQUAL(success(), push_action_msig( N(alice1111111), N(exec), mvo()
+   BOOST_REQUIRE_EQUAL(success(), push_action_msig( "alice1111111"_n, "exec"_n, mvo()
                                                     ("proposer",      "alice1111111")
                                                     ("proposal_name", "upgrade1")
                                                     ("executer",      "alice1111111")
@@ -2834,9 +2834,9 @@ BOOST_FIXTURE_TEST_CASE(producers_upgrade_system_contract, eosio_system_tester) 
 BOOST_FIXTURE_TEST_CASE(producer_onblock_check, eosio_system_tester) try {
 
    const asset large_asset = core_sym::from_string("80.0000");
-   create_account_with_resources( N(producvotera), config::system_account_name, core_sym::from_string("1.0000"), false, large_asset, large_asset );
-   create_account_with_resources( N(producvoterb), config::system_account_name, core_sym::from_string("1.0000"), false, large_asset, large_asset );
-   create_account_with_resources( N(producvoterc), config::system_account_name, core_sym::from_string("1.0000"), false, large_asset, large_asset );
+   create_account_with_resources( "producvotera"_n, config::system_account_name, core_sym::from_string("1.0000"), false, large_asset, large_asset );
+   create_account_with_resources( "producvoterb"_n, config::system_account_name, core_sym::from_string("1.0000"), false, large_asset, large_asset );
+   create_account_with_resources( "producvoterc"_n, config::system_account_name, core_sym::from_string("1.0000"), false, large_asset, large_asset );
 
    // create accounts {defproducera, defproducerb, ..., defproducerz} and register as producers
    std::vector<account_name> producer_names;
@@ -2858,7 +2858,7 @@ BOOST_FIXTURE_TEST_CASE(producer_onblock_check, eosio_system_tester) try {
 
    transfer(config::system_account_name, "producvotera", core_sym::from_string("200000000.0000"), config::system_account_name);
    BOOST_REQUIRE_EQUAL(success(), stake("producvotera", core_sym::from_string("70000000.0000"), core_sym::from_string("70000000.0000") ));
-   BOOST_REQUIRE_EQUAL(success(), vote( N(producvotera), vector<account_name>(producer_names.begin(), producer_names.begin()+10)));
+   BOOST_REQUIRE_EQUAL(success(), vote( "producvotera"_n, vector<account_name>(producer_names.begin(), producer_names.begin()+10)));
    BOOST_CHECK_EQUAL( wasm_assert_msg( "cannot undelegate bandwidth until the chain is activated (at least 15% of all tokens participate in voting)" ),
                       unstake( "producvotera", core_sym::from_string("50.0000"), core_sym::from_string("50.0000") ) );
 
@@ -2885,10 +2885,10 @@ BOOST_FIXTURE_TEST_CASE(producer_onblock_check, eosio_system_tester) try {
       const char* claimrewards_activation_error_message = "cannot claim rewards until the chain is activated (at least 15% of all tokens participate in voting)";
       BOOST_CHECK_EQUAL(0, get_global_state()["total_unpaid_blocks"].as<uint32_t>());
       BOOST_REQUIRE_EQUAL(wasm_assert_msg( claimrewards_activation_error_message ),
-                          push_action(producer_names.front(), N(claimrewards), mvo()("owner", producer_names.front())));
+                          push_action(producer_names.front(), "claimrewards"_n, mvo()("owner", producer_names.front())));
       BOOST_REQUIRE_EQUAL(0, get_balance(producer_names.front()).get_amount());
       BOOST_REQUIRE_EQUAL(wasm_assert_msg( claimrewards_activation_error_message ),
-                          push_action(producer_names.back(), N(claimrewards), mvo()("owner", producer_names.back())));
+                          push_action(producer_names.back(), "claimrewards"_n, mvo()("owner", producer_names.back())));
       BOOST_REQUIRE_EQUAL(0, get_balance(producer_names.back()).get_amount());
    }
 
@@ -2898,8 +2898,8 @@ BOOST_FIXTURE_TEST_CASE(producer_onblock_check, eosio_system_tester) try {
    transfer(config::system_account_name, "producvoterc", core_sym::from_string("100000000.0000"), config::system_account_name);
    BOOST_REQUIRE_EQUAL(success(), stake("producvoterc", core_sym::from_string("2000000.0000"), core_sym::from_string("2000000.0000")));
 
-   BOOST_REQUIRE_EQUAL(success(), vote( N(producvoterb), vector<account_name>(producer_names.begin(), producer_names.begin()+21)));
-   BOOST_REQUIRE_EQUAL(success(), vote( N(producvoterc), vector<account_name>(producer_names.begin(), producer_names.end())));
+   BOOST_REQUIRE_EQUAL(success(), vote( "producvoterb"_n, vector<account_name>(producer_names.begin(), producer_names.begin()+21)));
+   BOOST_REQUIRE_EQUAL(success(), vote( "producvoterc"_n, vector<account_name>(producer_names.begin(), producer_names.end())));
 
    // give a chance for everyone to produce blocks
    {
@@ -2919,7 +2919,7 @@ BOOST_FIXTURE_TEST_CASE(producer_onblock_check, eosio_system_tester) try {
       BOOST_REQUIRE_EQUAL(true, all_21_produced);
       BOOST_REQUIRE_EQUAL(true, rest_didnt_produce);
       BOOST_REQUIRE_EQUAL(success(),
-                          push_action(producer_names.front(), N(claimrewards), mvo()("owner", producer_names.front())));
+                          push_action(producer_names.front(), "claimrewards"_n, mvo()("owner", producer_names.front())));
       BOOST_REQUIRE(0 < get_balance(producer_names.front()).get_amount());
    }
 
@@ -2930,38 +2930,38 @@ BOOST_FIXTURE_TEST_CASE(producer_onblock_check, eosio_system_tester) try {
 BOOST_FIXTURE_TEST_CASE( voters_actions_affect_proxy_and_producers, eosio_system_tester, * boost::unit_test::tolerance(1e+6) ) try {
    cross_15_percent_threshold();
 
-   create_accounts_with_resources( { N(donald111111), N(defproducer1), N(defproducer2), N(defproducer3) } );
-   BOOST_REQUIRE_EQUAL( success(), regproducer( N(defproducer1), 1) );
-   BOOST_REQUIRE_EQUAL( success(), regproducer( N(defproducer2), 2) );
-   BOOST_REQUIRE_EQUAL( success(), regproducer( N(defproducer3), 3) );
+   create_accounts_with_resources( { "donald111111"_n, "defproducer1"_n, "defproducer2"_n, "defproducer3"_n } );
+   BOOST_REQUIRE_EQUAL( success(), regproducer( "defproducer1"_n, 1) );
+   BOOST_REQUIRE_EQUAL( success(), regproducer( "defproducer2"_n, 2) );
+   BOOST_REQUIRE_EQUAL( success(), regproducer( "defproducer3"_n, 3) );
 
    //alice1111111 becomes a producer
-   BOOST_REQUIRE_EQUAL( success(), push_action( N(alice1111111), N(regproxy), mvo()
+   BOOST_REQUIRE_EQUAL( success(), push_action( "alice1111111"_n, "regproxy"_n, mvo()
                                                 ("proxy",  "alice1111111")
                                                 ("isproxy", true)
                         )
    );
-   REQUIRE_MATCHING_OBJECT( proxy( N(alice1111111) ), get_voter_info( "alice1111111" ) );
+   REQUIRE_MATCHING_OBJECT( proxy( "alice1111111"_n ), get_voter_info( "alice1111111" ) );
 
    //alice1111111 makes stake and votes
    issue_and_transfer( "alice1111111", core_sym::from_string("1000.0000"),  config::system_account_name );
    BOOST_REQUIRE_EQUAL( success(), stake( "alice1111111", core_sym::from_string("30.0001"), core_sym::from_string("20.0001") ) );
-   BOOST_REQUIRE_EQUAL( success(), vote( N(alice1111111), { N(defproducer1), N(defproducer2) } ) );
+   BOOST_REQUIRE_EQUAL( success(), vote( "alice1111111"_n, { "defproducer1"_n, "defproducer2"_n } ) );
    BOOST_TEST_REQUIRE( stake2votes(core_sym::from_string("50.0002")) == get_producer_info( "defproducer1" )["total_votes"].as_double() );
    BOOST_TEST_REQUIRE( stake2votes(core_sym::from_string("50.0002")) == get_producer_info( "defproducer2" )["total_votes"].as_double() );
    BOOST_REQUIRE_EQUAL( 0, get_producer_info( "defproducer3" )["total_votes"].as_double() );
 
-   BOOST_REQUIRE_EQUAL( success(), push_action( N(donald111111), N(regproxy), mvo()
+   BOOST_REQUIRE_EQUAL( success(), push_action( "donald111111"_n, "regproxy"_n, mvo()
                                                 ("proxy",  "donald111111")
                                                 ("isproxy", true)
                         )
    );
-   REQUIRE_MATCHING_OBJECT( proxy( N(donald111111) ), get_voter_info( "donald111111" ) );
+   REQUIRE_MATCHING_OBJECT( proxy( "donald111111"_n ), get_voter_info( "donald111111" ) );
 
    //bob111111111 chooses alice1111111 as a proxy
    issue_and_transfer( "bob111111111", core_sym::from_string("1000.0000"),  config::system_account_name );
    BOOST_REQUIRE_EQUAL( success(), stake( "bob111111111", core_sym::from_string("100.0002"), core_sym::from_string("50.0001") ) );
-   BOOST_REQUIRE_EQUAL( success(), vote( N(bob111111111), vector<account_name>(), "alice1111111" ) );
+   BOOST_REQUIRE_EQUAL( success(), vote( "bob111111111"_n, vector<account_name>(), "alice1111111" ) );
    BOOST_TEST_REQUIRE( stake2votes(core_sym::from_string("150.0003")) == get_voter_info( "alice1111111" )["proxied_vote_weight"].as_double() );
    BOOST_TEST_REQUIRE( stake2votes(core_sym::from_string("200.0005")) == get_producer_info( "defproducer1" )["total_votes"].as_double() );
    BOOST_TEST_REQUIRE( stake2votes(core_sym::from_string("200.0005")) == get_producer_info( "defproducer2" )["total_votes"].as_double() );
@@ -2970,7 +2970,7 @@ BOOST_FIXTURE_TEST_CASE( voters_actions_affect_proxy_and_producers, eosio_system
    //carol1111111 chooses alice1111111 as a proxy
    issue_and_transfer( "carol1111111", core_sym::from_string("1000.0000"),  config::system_account_name );
    BOOST_REQUIRE_EQUAL( success(), stake( "carol1111111", core_sym::from_string("30.0001"), core_sym::from_string("20.0001") ) );
-   BOOST_REQUIRE_EQUAL( success(), vote( N(carol1111111), vector<account_name>(), "alice1111111" ) );
+   BOOST_REQUIRE_EQUAL( success(), vote( "carol1111111"_n, vector<account_name>(), "alice1111111" ) );
    BOOST_TEST_REQUIRE( stake2votes(core_sym::from_string("200.0005")) == get_voter_info( "alice1111111" )["proxied_vote_weight"].as_double() );
    BOOST_TEST_REQUIRE( stake2votes(core_sym::from_string("250.0007")) == get_producer_info( "defproducer1" )["total_votes"].as_double() );
    BOOST_TEST_REQUIRE( stake2votes(core_sym::from_string("250.0007")) == get_producer_info( "defproducer2" )["total_votes"].as_double() );
@@ -2991,7 +2991,7 @@ BOOST_FIXTURE_TEST_CASE( voters_actions_affect_proxy_and_producers, eosio_system
    BOOST_REQUIRE_EQUAL( 0, get_producer_info( "defproducer3" )["total_votes"].as_double() );
 
    //proxied voter carol1111111 chooses another proxy
-   BOOST_REQUIRE_EQUAL( success(), vote( N(carol1111111), vector<account_name>(), "donald111111" ) );
+   BOOST_REQUIRE_EQUAL( success(), vote( "carol1111111"_n, vector<account_name>(), "donald111111" ) );
    BOOST_TEST_REQUIRE( stake2votes(core_sym::from_string("50.0001")), get_voter_info( "alice1111111" )["proxied_vote_weight"].as_double() );
    BOOST_TEST_REQUIRE( stake2votes(core_sym::from_string("170.0002")), get_voter_info( "donald111111" )["proxied_vote_weight"].as_double() );
    BOOST_TEST_REQUIRE( stake2votes(core_sym::from_string("100.0003")), get_producer_info( "defproducer1" )["total_votes"].as_double() );
@@ -2999,7 +2999,7 @@ BOOST_FIXTURE_TEST_CASE( voters_actions_affect_proxy_and_producers, eosio_system
    BOOST_REQUIRE_EQUAL( 0, get_producer_info( "defproducer3" )["total_votes"].as_double() );
 
    //bob111111111 switches to direct voting and votes for one of the same producers, but not for another one
-   BOOST_REQUIRE_EQUAL( success(), vote( N(bob111111111), { N(defproducer2) } ) );
+   BOOST_REQUIRE_EQUAL( success(), vote( "bob111111111"_n, { "defproducer2"_n } ) );
    BOOST_TEST_REQUIRE( 0.0 == get_voter_info( "alice1111111" )["proxied_vote_weight"].as_double() );
    BOOST_TEST_REQUIRE(  stake2votes(core_sym::from_string("50.0002")), get_producer_info( "defproducer1" )["total_votes"].as_double() );
    BOOST_TEST_REQUIRE( stake2votes(core_sym::from_string("100.0003")), get_producer_info( "defproducer2" )["total_votes"].as_double() );
@@ -3010,22 +3010,22 @@ BOOST_FIXTURE_TEST_CASE( voters_actions_affect_proxy_and_producers, eosio_system
 
 BOOST_FIXTURE_TEST_CASE( vote_both_proxy_and_producers, eosio_system_tester ) try {
    //alice1111111 becomes a proxy
-   BOOST_REQUIRE_EQUAL( success(), push_action( N(alice1111111), N(regproxy), mvo()
+   BOOST_REQUIRE_EQUAL( success(), push_action( "alice1111111"_n, "regproxy"_n, mvo()
                                                 ("proxy",  "alice1111111")
                                                 ("isproxy", true)
                         )
    );
-   REQUIRE_MATCHING_OBJECT( proxy( N(alice1111111) ), get_voter_info( "alice1111111" ) );
+   REQUIRE_MATCHING_OBJECT( proxy( "alice1111111"_n ), get_voter_info( "alice1111111" ) );
 
    //carol1111111 becomes a producer
-   BOOST_REQUIRE_EQUAL( success(), regproducer( N(carol1111111), 1) );
+   BOOST_REQUIRE_EQUAL( success(), regproducer( "carol1111111"_n, 1) );
 
    //bob111111111 chooses alice1111111 as a proxy
 
    issue_and_transfer( "bob111111111", core_sym::from_string("1000.0000"),  config::system_account_name );
    BOOST_REQUIRE_EQUAL( success(), stake( "bob111111111", core_sym::from_string("100.0002"), core_sym::from_string("50.0001") ) );
    BOOST_REQUIRE_EQUAL( wasm_assert_msg("cannot vote for producers and proxy at same time"),
-                        vote( N(bob111111111), { N(carol1111111) }, "alice1111111" ) );
+                        vote( "bob111111111"_n, { "carol1111111"_n }, "alice1111111" ) );
 
 } FC_LOG_AND_RETHROW()
 
@@ -3037,18 +3037,18 @@ BOOST_FIXTURE_TEST_CASE( select_invalid_proxy, eosio_system_tester ) try {
 
    //selecting account not registered as a proxy
    BOOST_REQUIRE_EQUAL( wasm_assert_msg( "invalid proxy specified" ),
-                        vote( N(bob111111111), vector<account_name>(), "alice1111111" ) );
+                        vote( "bob111111111"_n, vector<account_name>(), "alice1111111" ) );
 
    //selecting not existing account as a proxy
    BOOST_REQUIRE_EQUAL( wasm_assert_msg( "invalid proxy specified" ),
-                        vote( N(bob111111111), vector<account_name>(), "notexist" ) );
+                        vote( "bob111111111"_n, vector<account_name>(), "notexist" ) );
 
 } FC_LOG_AND_RETHROW()
 
 
 BOOST_FIXTURE_TEST_CASE( double_register_unregister_proxy_keeps_votes, eosio_system_tester ) try {
    //alice1111111 becomes a proxy
-   BOOST_REQUIRE_EQUAL( success(), push_action( N(alice1111111), N(regproxy), mvo()
+   BOOST_REQUIRE_EQUAL( success(), push_action( "alice1111111"_n, "regproxy"_n, mvo()
                                                 ("proxy",  "alice1111111")
                                                 ("isproxy",  1)
                         )
@@ -3056,25 +3056,25 @@ BOOST_FIXTURE_TEST_CASE( double_register_unregister_proxy_keeps_votes, eosio_sys
    issue_and_transfer( "alice1111111", core_sym::from_string("1000.0000"),  config::system_account_name );
    BOOST_REQUIRE_EQUAL( success(), stake( "alice1111111", core_sym::from_string("5.0000"), core_sym::from_string("5.0000") ) );
    edump((get_voter_info("alice1111111")));
-   REQUIRE_MATCHING_OBJECT( proxy( N(alice1111111) )( "staked", 100000 ), get_voter_info( "alice1111111" ) );
+   REQUIRE_MATCHING_OBJECT( proxy( "alice1111111"_n )( "staked", 100000 ), get_voter_info( "alice1111111" ) );
 
    //bob111111111 stakes and selects alice1111111 as a proxy
    issue_and_transfer( "bob111111111", core_sym::from_string("1000.0000"),  config::system_account_name );
    BOOST_REQUIRE_EQUAL( success(), stake( "bob111111111", core_sym::from_string("100.0002"), core_sym::from_string("50.0001") ) );
-   BOOST_REQUIRE_EQUAL( success(), vote( N(bob111111111), vector<account_name>(), "alice1111111" ) );
-   REQUIRE_MATCHING_OBJECT( proxy( N(alice1111111) )( "proxied_vote_weight", stake2votes( core_sym::from_string("150.0003") ))( "staked", 100000 ), get_voter_info( "alice1111111" ) );
+   BOOST_REQUIRE_EQUAL( success(), vote( "bob111111111"_n, vector<account_name>(), "alice1111111" ) );
+   REQUIRE_MATCHING_OBJECT( proxy( "alice1111111"_n )( "proxied_vote_weight", stake2votes( core_sym::from_string("150.0003") ))( "staked", 100000 ), get_voter_info( "alice1111111" ) );
 
    //double regestering should fail without affecting total votes and stake
    BOOST_REQUIRE_EQUAL( wasm_assert_msg( "action has no effect" ),
-                        push_action( N(alice1111111), N(regproxy), mvo()
+                        push_action( "alice1111111"_n, "regproxy"_n, mvo()
                                      ("proxy",  "alice1111111")
                                      ("isproxy",  1)
                         )
    );
-   REQUIRE_MATCHING_OBJECT( proxy( N(alice1111111) )( "proxied_vote_weight", stake2votes(core_sym::from_string("150.0003")) )( "staked", 100000 ), get_voter_info( "alice1111111" ) );
+   REQUIRE_MATCHING_OBJECT( proxy( "alice1111111"_n )( "proxied_vote_weight", stake2votes(core_sym::from_string("150.0003")) )( "staked", 100000 ), get_voter_info( "alice1111111" ) );
 
    //uregister
-   BOOST_REQUIRE_EQUAL( success(), push_action( N(alice1111111), N(regproxy), mvo()
+   BOOST_REQUIRE_EQUAL( success(), push_action( "alice1111111"_n, "regproxy"_n, mvo()
                                                 ("proxy",  "alice1111111")
                                                 ("isproxy",  0)
                         )
@@ -3083,7 +3083,7 @@ BOOST_FIXTURE_TEST_CASE( double_register_unregister_proxy_keeps_votes, eosio_sys
 
    //double unregistering should not affect proxied_votes and stake
    BOOST_REQUIRE_EQUAL( wasm_assert_msg( "action has no effect" ),
-                        push_action( N(alice1111111), N(regproxy), mvo()
+                        push_action( "alice1111111"_n, "regproxy"_n, mvo()
                                      ("proxy",  "alice1111111")
                                      ("isproxy",  0)
                         )
@@ -3095,14 +3095,14 @@ BOOST_FIXTURE_TEST_CASE( double_register_unregister_proxy_keeps_votes, eosio_sys
 
 BOOST_FIXTURE_TEST_CASE( proxy_cannot_use_another_proxy, eosio_system_tester ) try {
    //alice1111111 becomes a proxy
-   BOOST_REQUIRE_EQUAL( success(), push_action( N(alice1111111), N(regproxy), mvo()
+   BOOST_REQUIRE_EQUAL( success(), push_action( "alice1111111"_n, "regproxy"_n, mvo()
                                                 ("proxy",  "alice1111111")
                                                 ("isproxy",  1)
                         )
    );
 
    //bob111111111 becomes a proxy
-   BOOST_REQUIRE_EQUAL( success(), push_action( N(bob111111111), N(regproxy), mvo()
+   BOOST_REQUIRE_EQUAL( success(), push_action( "bob111111111"_n, "regproxy"_n, mvo()
                                                 ("proxy",  "bob111111111")
                                                 ("isproxy",  1)
                         )
@@ -3112,14 +3112,14 @@ BOOST_FIXTURE_TEST_CASE( proxy_cannot_use_another_proxy, eosio_system_tester ) t
    issue_and_transfer( "bob111111111", core_sym::from_string("1000.0000"),  config::system_account_name );
    BOOST_REQUIRE_EQUAL( success(), stake( "bob111111111", core_sym::from_string("100.0002"), core_sym::from_string("50.0001") ) );
    BOOST_REQUIRE_EQUAL( wasm_assert_msg( "account registered as a proxy is not allowed to use a proxy" ),
-                        vote( N(bob111111111), vector<account_name>(), "alice1111111" ) );
+                        vote( "bob111111111"_n, vector<account_name>(), "alice1111111" ) );
 
    //voter that uses a proxy should not be allowed to become a proxy
    issue_and_transfer( "carol1111111", core_sym::from_string("1000.0000"),  config::system_account_name );
    BOOST_REQUIRE_EQUAL( success(), stake( "carol1111111", core_sym::from_string("100.0002"), core_sym::from_string("50.0001") ) );
-   BOOST_REQUIRE_EQUAL( success(), vote( N(carol1111111), vector<account_name>(), "alice1111111" ) );
+   BOOST_REQUIRE_EQUAL( success(), vote( "carol1111111"_n, vector<account_name>(), "alice1111111" ) );
    BOOST_REQUIRE_EQUAL( wasm_assert_msg( "account that uses a proxy is not allowed to become a proxy" ),
-                        push_action( N(carol1111111), N(regproxy), mvo()
+                        push_action( "carol1111111"_n, "regproxy"_n, mvo()
                                      ("proxy",  "carol1111111")
                                      ("isproxy",  1)
                         )
@@ -3127,7 +3127,7 @@ BOOST_FIXTURE_TEST_CASE( proxy_cannot_use_another_proxy, eosio_system_tester ) t
 
    //proxy should not be able to use itself as a proxy
    BOOST_REQUIRE_EQUAL( wasm_assert_msg( "cannot proxy to self" ),
-                        vote( N(bob111111111), vector<account_name>(), "bob111111111" ) );
+                        vote( "bob111111111"_n, vector<account_name>(), "bob111111111" ) );
 
 } FC_LOG_AND_RETHROW()
 
@@ -3152,16 +3152,16 @@ fc::mutable_variant_object config_to_variant( const eosio::chain::chain_config& 
 }
 
 BOOST_FIXTURE_TEST_CASE( elect_producers /*_and_parameters*/, eosio_system_tester ) try {
-   create_accounts_with_resources( {  N(defproducer1), N(defproducer2), N(defproducer3) } );
-   BOOST_REQUIRE_EQUAL( success(), regproducer( N(defproducer1), 1) );
-   BOOST_REQUIRE_EQUAL( success(), regproducer( N(defproducer2), 2) );
-   BOOST_REQUIRE_EQUAL( success(), regproducer( N(defproducer3), 3) );
+   create_accounts_with_resources( {  "defproducer1"_n, "defproducer2"_n, "defproducer3"_n } );
+   BOOST_REQUIRE_EQUAL( success(), regproducer( "defproducer1"_n, 1) );
+   BOOST_REQUIRE_EQUAL( success(), regproducer( "defproducer2"_n, 2) );
+   BOOST_REQUIRE_EQUAL( success(), regproducer( "defproducer3"_n, 3) );
 
    //stake more than 15% of total EOS supply to activate chain
    transfer( "eosio", "alice1111111", core_sym::from_string("600000000.0000"), "eosio" );
    BOOST_REQUIRE_EQUAL( success(), stake( "alice1111111", "alice1111111", core_sym::from_string("300000000.0000"), core_sym::from_string("300000000.0000") ) );
    //vote for producers
-   BOOST_REQUIRE_EQUAL( success(), vote( N(alice1111111), { N(defproducer1) } ) );
+   BOOST_REQUIRE_EQUAL( success(), vote( "alice1111111"_n, { "defproducer1"_n } ) );
    produce_blocks(250);
    auto producer_keys = control->head_block_state()->active_schedule.producers;
    BOOST_REQUIRE_EQUAL( 1, producer_keys.size() );
@@ -3176,7 +3176,7 @@ BOOST_FIXTURE_TEST_CASE( elect_producers /*_and_parameters*/, eosio_system_teste
    ilog("stake");
    BOOST_REQUIRE_EQUAL( success(), stake( "bob111111111", core_sym::from_string("40000.0000"), core_sym::from_string("40000.0000") ) );
    ilog("start vote");
-   BOOST_REQUIRE_EQUAL( success(), vote( N(bob111111111), { N(defproducer2) } ) );
+   BOOST_REQUIRE_EQUAL( success(), vote( "bob111111111"_n, { "defproducer2"_n } ) );
    ilog(".");
    produce_blocks(250);
    producer_keys = control->head_block_state()->active_schedule.producers;
@@ -3188,7 +3188,7 @@ BOOST_FIXTURE_TEST_CASE( elect_producers /*_and_parameters*/, eosio_system_teste
    //REQUIRE_EQUAL_OBJECTS(prod2_config, config);
 
    // elect 3 producers
-   BOOST_REQUIRE_EQUAL( success(), vote( N(bob111111111), { N(defproducer2), N(defproducer3) } ) );
+   BOOST_REQUIRE_EQUAL( success(), vote( "bob111111111"_n, { "defproducer2"_n, "defproducer3"_n } ) );
    produce_blocks(250);
    producer_keys = control->head_block_state()->active_schedule.producers;
    BOOST_REQUIRE_EQUAL( 3, producer_keys.size() );
@@ -3199,7 +3199,7 @@ BOOST_FIXTURE_TEST_CASE( elect_producers /*_and_parameters*/, eosio_system_teste
    //REQUIRE_EQUAL_OBJECTS(prod2_config, config);
 
    // try to go back to 2 producers and fail
-   BOOST_REQUIRE_EQUAL( success(), vote( N(bob111111111), { N(defproducer3) } ) );
+   BOOST_REQUIRE_EQUAL( success(), vote( "bob111111111"_n, { "defproducer3"_n } ) );
    produce_blocks(250);
    producer_keys = control->head_block_state()->active_schedule.producers;
    BOOST_REQUIRE_EQUAL( 3, producer_keys.size() );
@@ -3219,21 +3219,21 @@ BOOST_FIXTURE_TEST_CASE( elect_producers /*_and_parameters*/, eosio_system_teste
 
 
 BOOST_FIXTURE_TEST_CASE( buyname, eosio_system_tester ) try {
-   create_accounts_with_resources( { N(dan), N(sam) } );
+   create_accounts_with_resources( { "dan"_n, "sam"_n } );
    transfer( config::system_account_name, "dan", core_sym::from_string( "10000.0000" ) );
    transfer( config::system_account_name, "sam", core_sym::from_string( "10000.0000" ) );
-   stake_with_transfer( config::system_account_name, N(sam), core_sym::from_string( "80000000.0000" ), core_sym::from_string( "80000000.0000" ) );
-   stake_with_transfer( config::system_account_name, N(dan), core_sym::from_string( "80000000.0000" ), core_sym::from_string( "80000000.0000" ) );
+   stake_with_transfer( config::system_account_name, "sam"_n, core_sym::from_string( "80000000.0000" ), core_sym::from_string( "80000000.0000" ) );
+   stake_with_transfer( config::system_account_name, "dan"_n, core_sym::from_string( "80000000.0000" ), core_sym::from_string( "80000000.0000" ) );
 
    regproducer( config::system_account_name );
-   BOOST_REQUIRE_EQUAL( success(), vote( N(sam), { config::system_account_name } ) );
+   BOOST_REQUIRE_EQUAL( success(), vote( "sam"_n, { config::system_account_name } ) );
    // wait 14 days after min required amount has been staked
    produce_block( fc::days(7) );
-   BOOST_REQUIRE_EQUAL( success(), vote( N(dan), { config::system_account_name } ) );
+   BOOST_REQUIRE_EQUAL( success(), vote( "dan"_n, { config::system_account_name } ) );
    produce_block( fc::days(7) );
    produce_block();
 
-   BOOST_REQUIRE_EXCEPTION( create_accounts_with_resources( { N(fail) }, N(dan) ), // dan shouldn't be able to create fail
+   BOOST_REQUIRE_EXCEPTION( create_accounts_with_resources( { "fail"_n }, "dan"_n ), // dan shouldn't be able to create fail
                             eosio_assert_message_exception, eosio_assert_message_is( "no active bid for name" ) );
    bidname( "dan", "nofail", core_sym::from_string( "1.0000" ) );
    BOOST_REQUIRE_EQUAL( "assertion failure with message: must increase bid by 10%", bidname( "sam", "nofail", core_sym::from_string( "1.0000" ) )); // didn't increase bid by 10%
@@ -3241,22 +3241,22 @@ BOOST_FIXTURE_TEST_CASE( buyname, eosio_system_tester ) try {
    produce_block( fc::days(1) );
    produce_block();
 
-   BOOST_REQUIRE_EXCEPTION( create_accounts_with_resources( { N(nofail) }, N(dan) ), // dan shoudn't be able to do this, sam won
+   BOOST_REQUIRE_EXCEPTION( create_accounts_with_resources( { "nofail"_n }, "dan"_n ), // dan shoudn't be able to do this, sam won
                             eosio_assert_message_exception, eosio_assert_message_is( "only highest bidder can claim" ) );
    //wlog( "verify sam can create nofail" );
-   create_accounts_with_resources( { N(nofail) }, N(sam) ); // sam should be able to do this, he won the bid
+   create_accounts_with_resources( { "nofail"_n }, "sam"_n ); // sam should be able to do this, he won the bid
    //wlog( "verify nofail can create test.nofail" );
    transfer( "eosio", "nofail", core_sym::from_string( "1000.0000" ) );
-   create_accounts_with_resources( { N(test.nofail) }, N(nofail) ); // only nofail can create test.nofail
+   create_accounts_with_resources( { "test.nofail"_n }, "nofail"_n ); // only nofail can create test.nofail
    //wlog( "verify dan cannot create test.fail" );
-   BOOST_REQUIRE_EXCEPTION( create_accounts_with_resources( { N(test.fail) }, N(dan) ), // dan shouldn't be able to do this
+   BOOST_REQUIRE_EXCEPTION( create_accounts_with_resources( { "test.fail"_n }, "dan"_n ), // dan shouldn't be able to do this
                             eosio_assert_message_exception, eosio_assert_message_is( "only suffix may create this account" ) );
 
-   create_accounts_with_resources( { N(goodgoodgood) }, N(dan) ); /// 12 char names should succeed
+   create_accounts_with_resources( { "goodgoodgood"_n }, "dan"_n ); /// 12 char names should succeed
 } FC_LOG_AND_RETHROW()
 
 BOOST_FIXTURE_TEST_CASE( bid_invalid_names, eosio_system_tester ) try {
-   create_accounts_with_resources( { N(dan) } );
+   create_accounts_with_resources( { "dan"_n } );
 
    BOOST_REQUIRE_EQUAL( wasm_assert_msg( "you can only bid on top-level suffix" ),
                         bidname( "dan", "abcdefg.12345", core_sym::from_string( "1.0000" ) ) );
@@ -3276,21 +3276,21 @@ BOOST_FIXTURE_TEST_CASE( multiple_namebids, eosio_system_tester ) try {
 
    const std::string not_closed_message("auction for name is not closed yet");
 
-   std::vector<account_name> accounts = { N(alice), N(bob), N(carl), N(david), N(eve) };
+   std::vector<account_name> accounts = { "alice"_n, "bob"_n, "carl"_n, "david"_n, "eve"_n };
    create_accounts_with_resources( accounts );
    for ( const auto& a: accounts ) {
       transfer( config::system_account_name, a, core_sym::from_string( "10000.0000" ) );
       BOOST_REQUIRE_EQUAL( core_sym::from_string( "10000.0000" ), get_balance(a) );
    }
-   create_accounts_with_resources( { N(producer) } );
-   BOOST_REQUIRE_EQUAL( success(), regproducer( N(producer) ) );
+   create_accounts_with_resources( { "producer"_n } );
+   BOOST_REQUIRE_EQUAL( success(), regproducer( "producer"_n ) );
 
    produce_block();
    // stake but but not enough to go live
-   stake_with_transfer( config::system_account_name, N(bob),  core_sym::from_string( "35000000.0000" ), core_sym::from_string( "35000000.0000" ) );
-   stake_with_transfer( config::system_account_name, N(carl), core_sym::from_string( "35000000.0000" ), core_sym::from_string( "35000000.0000" ) );
-   BOOST_REQUIRE_EQUAL( success(), vote( N(bob), { N(producer) } ) );
-   BOOST_REQUIRE_EQUAL( success(), vote( N(carl), { N(producer) } ) );
+   stake_with_transfer( config::system_account_name, "bob"_n,  core_sym::from_string( "35000000.0000" ), core_sym::from_string( "35000000.0000" ) );
+   stake_with_transfer( config::system_account_name, "carl"_n, core_sym::from_string( "35000000.0000" ), core_sym::from_string( "35000000.0000" ) );
+   BOOST_REQUIRE_EQUAL( success(), vote( "bob"_n, { "producer"_n } ) );
+   BOOST_REQUIRE_EQUAL( success(), vote( "carl"_n, { "producer"_n } ) );
 
    // start bids
    bidname( "bob",  "prefa", core_sym::from_string("1.0003") );
@@ -3312,12 +3312,12 @@ BOOST_FIXTURE_TEST_CASE( multiple_namebids, eosio_system_tester ) try {
 
    // alice outbids bob on prefb
    {
-      const asset initial_names_balance = get_balance(N(eosio.names));
+      const asset initial_names_balance = get_balance("eosio.names"_n);
       BOOST_REQUIRE_EQUAL( success(),
                            bidname( "alice", "prefb", core_sym::from_string("1.1001") ) );
       BOOST_REQUIRE_EQUAL( core_sym::from_string( "9997.9997" ), get_balance("bob") );
       BOOST_REQUIRE_EQUAL( core_sym::from_string( "9998.8999" ), get_balance("alice") );
-      BOOST_REQUIRE_EQUAL( initial_names_balance + core_sym::from_string("0.1001"), get_balance(N(eosio.names)) );
+      BOOST_REQUIRE_EQUAL( initial_names_balance + core_sym::from_string("0.1001"), get_balance("eosio.names"_n) );
    }
 
    // david outbids carl on prefd
@@ -3340,36 +3340,36 @@ BOOST_FIXTURE_TEST_CASE( multiple_namebids, eosio_system_tester ) try {
    produce_block();
 
    // highest bid is from david for prefd but no bids can be closed yet
-   BOOST_REQUIRE_EXCEPTION( create_account_with_resources( N(prefd), N(david) ),
+   BOOST_REQUIRE_EXCEPTION( create_account_with_resources( "prefd"_n, "david"_n ),
                             fc::exception, fc_assert_exception_message_is( not_closed_message ) );
 
    // stake enough to go above the 15% threshold
-   stake_with_transfer( config::system_account_name, N(alice), core_sym::from_string( "10000000.0000" ), core_sym::from_string( "10000000.0000" ) );
+   stake_with_transfer( config::system_account_name, "alice"_n, core_sym::from_string( "10000000.0000" ), core_sym::from_string( "10000000.0000" ) );
    BOOST_REQUIRE_EQUAL(0, get_producer_info("producer")["unpaid_blocks"].as<uint32_t>());
-   BOOST_REQUIRE_EQUAL( success(), vote( N(alice), { N(producer) } ) );
+   BOOST_REQUIRE_EQUAL( success(), vote( "alice"_n, { "producer"_n } ) );
 
    // need to wait for 14 days after going live
    produce_blocks(10);
    produce_block( fc::days(2) );
    produce_blocks( 10 );
-   BOOST_REQUIRE_EXCEPTION( create_account_with_resources( N(prefd), N(david) ),
+   BOOST_REQUIRE_EXCEPTION( create_account_with_resources( "prefd"_n, "david"_n ),
                             fc::exception, fc_assert_exception_message_is( not_closed_message ) );
    // it's been 14 days, auction for prefd has been closed
    produce_block( fc::days(12) );
-   create_account_with_resources( N(prefd), N(david) );
+   create_account_with_resources( "prefd"_n, "david"_n );
    produce_blocks(2);
    produce_block( fc::hours(23) );
    // auctions for prefa, prefb, prefc, prefe haven't been closed
-   BOOST_REQUIRE_EXCEPTION( create_account_with_resources( N(prefa), N(bob) ),
+   BOOST_REQUIRE_EXCEPTION( create_account_with_resources( "prefa"_n, "bob"_n ),
                             fc::exception, fc_assert_exception_message_is( not_closed_message ) );
-   BOOST_REQUIRE_EXCEPTION( create_account_with_resources( N(prefb), N(alice) ),
+   BOOST_REQUIRE_EXCEPTION( create_account_with_resources( "prefb"_n, "alice"_n ),
                             fc::exception, fc_assert_exception_message_is( not_closed_message ) );
-   BOOST_REQUIRE_EXCEPTION( create_account_with_resources( N(prefc), N(bob) ),
+   BOOST_REQUIRE_EXCEPTION( create_account_with_resources( "prefc"_n, "bob"_n ),
                             fc::exception, fc_assert_exception_message_is( not_closed_message ) );
-   BOOST_REQUIRE_EXCEPTION( create_account_with_resources( N(prefe), N(eve) ),
+   BOOST_REQUIRE_EXCEPTION( create_account_with_resources( "prefe"_n, "eve"_n ),
                             fc::exception, fc_assert_exception_message_is( not_closed_message ) );
    // attemp to create account with no bid
-   BOOST_REQUIRE_EXCEPTION( create_account_with_resources( N(prefg), N(alice) ),
+   BOOST_REQUIRE_EXCEPTION( create_account_with_resources( "prefg"_n, "alice"_n ),
                             fc::exception, fc_assert_exception_message_is( "no active bid for name" ) );
    // changing highest bid pushes auction closing time by 24 hours
    BOOST_REQUIRE_EQUAL( success(),
@@ -3378,7 +3378,7 @@ BOOST_FIXTURE_TEST_CASE( multiple_namebids, eosio_system_tester ) try {
    produce_block( fc::hours(22) );
    produce_blocks(2);
 
-   BOOST_REQUIRE_EXCEPTION( create_account_with_resources( N(prefb), N(eve) ),
+   BOOST_REQUIRE_EXCEPTION( create_account_with_resources( "prefb"_n, "eve"_n ),
                             fc::exception, fc_assert_exception_message_is( not_closed_message ) );
    // but changing a bid that is not the highest does not push closing time
    BOOST_REQUIRE_EQUAL( success(),
@@ -3386,26 +3386,26 @@ BOOST_FIXTURE_TEST_CASE( multiple_namebids, eosio_system_tester ) try {
    produce_block( fc::hours(2) );
    produce_blocks(2);
    // bid for prefb has closed, only highest bidder can claim
-   BOOST_REQUIRE_EXCEPTION( create_account_with_resources( N(prefb), N(alice) ),
+   BOOST_REQUIRE_EXCEPTION( create_account_with_resources( "prefb"_n, "alice"_n ),
                             eosio_assert_message_exception, eosio_assert_message_is( "only highest bidder can claim" ) );
-   BOOST_REQUIRE_EXCEPTION( create_account_with_resources( N(prefb), N(carl) ),
+   BOOST_REQUIRE_EXCEPTION( create_account_with_resources( "prefb"_n, "carl"_n ),
                             eosio_assert_message_exception, eosio_assert_message_is( "only highest bidder can claim" ) );
-   create_account_with_resources( N(prefb), N(eve) );
+   create_account_with_resources( "prefb"_n, "eve"_n );
 
-   BOOST_REQUIRE_EXCEPTION( create_account_with_resources( N(prefe), N(carl) ),
+   BOOST_REQUIRE_EXCEPTION( create_account_with_resources( "prefe"_n, "carl"_n ),
                             fc::exception, fc_assert_exception_message_is( not_closed_message ) );
    produce_block();
    produce_block( fc::hours(24) );
    // by now bid for prefe has closed
-   create_account_with_resources( N(prefe), N(carl) );
+   create_account_with_resources( "prefe"_n, "carl"_n );
    // prefe can now create *.prefe
-   BOOST_REQUIRE_EXCEPTION( create_account_with_resources( N(xyz.prefe), N(carl) ),
+   BOOST_REQUIRE_EXCEPTION( create_account_with_resources( "xyz.prefe"_n, "carl"_n ),
                             fc::exception, fc_assert_exception_message_is("only suffix may create this account") );
-   transfer( config::system_account_name, N(prefe), core_sym::from_string("10000.0000") );
-   create_account_with_resources( N(xyz.prefe), N(prefe) );
+   transfer( config::system_account_name, "prefe"_n, core_sym::from_string("10000.0000") );
+   create_account_with_resources( "xyz.prefe"_n, "prefe"_n );
 
    // other auctions haven't closed
-   BOOST_REQUIRE_EXCEPTION( create_account_with_resources( N(prefa), N(bob) ),
+   BOOST_REQUIRE_EXCEPTION( create_account_with_resources( "prefa"_n, "bob"_n ),
                             fc::exception, fc_assert_exception_message_is( not_closed_message ) );
 
 } FC_LOG_AND_RETHROW()
@@ -3413,8 +3413,8 @@ BOOST_FIXTURE_TEST_CASE( multiple_namebids, eosio_system_tester ) try {
 BOOST_FIXTURE_TEST_CASE( namebid_pending_winner, eosio_system_tester ) try {
    cross_15_percent_threshold();
    produce_block( fc::hours(14*24) );    //wait 14 day for name auction activation
-   transfer( config::system_account_name, N(alice1111111), core_sym::from_string("10000.0000") );
-   transfer( config::system_account_name, N(bob111111111), core_sym::from_string("10000.0000") );
+   transfer( config::system_account_name, "alice1111111"_n, core_sym::from_string("10000.0000") );
+   transfer( config::system_account_name, "bob111111111"_n, core_sym::from_string("10000.0000") );
 
    BOOST_REQUIRE_EQUAL( success(), bidname( "alice1111111", "prefa", core_sym::from_string( "50.0000" ) ));
    BOOST_REQUIRE_EQUAL( success(), bidname( "bob111111111", "prefb", core_sym::from_string( "30.0000" ) ));
@@ -3422,14 +3422,14 @@ BOOST_FIXTURE_TEST_CASE( namebid_pending_winner, eosio_system_tester ) try {
    produce_block( fc::hours(100) ); //should close "perfb"
 
    //despite "perfa" account hasn't been created, we should be able to create "perfb" account
-   create_account_with_resources( N(prefb), N(bob111111111) );
+   create_account_with_resources( "prefb"_n, "bob111111111"_n );
 } FC_LOG_AND_RETHROW()
 
 BOOST_FIXTURE_TEST_CASE( vote_producers_in_and_out, eosio_system_tester ) try {
 
    const asset net = core_sym::from_string("80.0000");
    const asset cpu = core_sym::from_string("80.0000");
-   std::vector<account_name> voters = { N(producvotera), N(producvoterb), N(producvoterc), N(producvoterd) };
+   std::vector<account_name> voters = { "producvotera"_n, "producvoterb"_n, "producvoterc"_n, "producvoterd"_n };
    for (const auto& v: voters) {
       create_account_with_resources(v, config::system_account_name, core_sym::from_string("1.0000"), false, net, cpu);
    }
@@ -3458,9 +3458,9 @@ BOOST_FIXTURE_TEST_CASE( vote_producers_in_and_out, eosio_system_tester ) try {
    }
 
    {
-      BOOST_REQUIRE_EQUAL(success(), vote(N(producvotera), vector<account_name>(producer_names.begin(), producer_names.begin()+20)));
-      BOOST_REQUIRE_EQUAL(success(), vote(N(producvoterb), vector<account_name>(producer_names.begin(), producer_names.begin()+21)));
-      BOOST_REQUIRE_EQUAL(success(), vote(N(producvoterc), vector<account_name>(producer_names.begin(), producer_names.end())));
+      BOOST_REQUIRE_EQUAL(success(), vote("producvotera"_n, vector<account_name>(producer_names.begin(), producer_names.begin()+20)));
+      BOOST_REQUIRE_EQUAL(success(), vote("producvoterb"_n, vector<account_name>(producer_names.begin(), producer_names.begin()+21)));
+      BOOST_REQUIRE_EQUAL(success(), vote("producvoterc"_n, vector<account_name>(producer_names.begin(), producer_names.end())));
    }
 
    // give a chance for everyone to produce blocks
@@ -3486,7 +3486,7 @@ BOOST_FIXTURE_TEST_CASE( vote_producers_in_and_out, eosio_system_tester ) try {
       const uint32_t voted_out_index = 20;
       const uint32_t new_prod_index  = 23;
       BOOST_REQUIRE_EQUAL(success(), stake("producvoterd", core_sym::from_string("40000000.0000"), core_sym::from_string("40000000.0000")));
-      BOOST_REQUIRE_EQUAL(success(), vote(N(producvoterd), { producer_names[new_prod_index] }));
+      BOOST_REQUIRE_EQUAL(success(), vote("producvoterd"_n, { producer_names[new_prod_index] }));
       BOOST_REQUIRE_EQUAL(0, get_producer_info(producer_names[new_prod_index])["unpaid_blocks"].as<uint32_t>());
       produce_blocks(4 * 12 * 21);
       BOOST_REQUIRE(0 < get_producer_info(producer_names[new_prod_index])["unpaid_blocks"].as<uint32_t>());
@@ -3494,10 +3494,10 @@ BOOST_FIXTURE_TEST_CASE( vote_producers_in_and_out, eosio_system_tester ) try {
       produce_blocks(2 * 12 * 21);
       BOOST_REQUIRE_EQUAL(initial_unpaid_blocks, get_producer_info(producer_names[voted_out_index])["unpaid_blocks"].as<uint32_t>());
       produce_block(fc::hours(24));
-      BOOST_REQUIRE_EQUAL(success(), vote(N(producvoterd), { producer_names[voted_out_index] }));
+      BOOST_REQUIRE_EQUAL(success(), vote("producvoterd"_n, { producer_names[voted_out_index] }));
       produce_blocks(2 * 12 * 21);
       BOOST_REQUIRE(fc::crypto::public_key() != fc::crypto::public_key(get_producer_info(producer_names[voted_out_index])["producer_key"].as_string()));
-      BOOST_REQUIRE_EQUAL(success(), push_action(producer_names[voted_out_index], N(claimrewards), mvo()("owner", producer_names[voted_out_index])));
+      BOOST_REQUIRE_EQUAL(success(), push_action(producer_names[voted_out_index], "claimrewards"_n, mvo()("owner", producer_names[voted_out_index])));
    }
 
 } FC_LOG_AND_RETHROW()
@@ -3512,11 +3512,11 @@ BOOST_FIXTURE_TEST_CASE( setparams, eosio_system_tester ) try {
          string action_type_name = msig_abi_ser.get_action_type(name);
 
          action act;
-         act.account = N(eosio.msig);
+         act.account = "eosio.msig"_n;
          act.name = name;
          act.data = msig_abi_ser.variant_to_binary( action_type_name, data, abi_serializer::create_yield_function(abi_serializer_max_time) );
 
-         return base_tester::push_action( std::move(act), (auth ? signer : signer == N(bob111111111) ? N(alice1111111) : N(bob111111111)).to_uint64_t() );
+         return base_tester::push_action( std::move(act), (auth ? signer : signer == "bob111111111"_n ? "alice1111111"_n : "bob111111111"_n).to_uint64_t() );
    };
 
    // test begins
@@ -3533,7 +3533,7 @@ BOOST_FIXTURE_TEST_CASE( setparams, eosio_system_tester ) try {
 
    transaction trx;
    {
-      variant pretty_trx = fc::mutable_variant_object()
+      fc::variant pretty_trx = fc::mutable_variant_object()
          ("expiration", "2020-01-01T00:30")
          ("ref_block_num", 2)
          ("ref_block_prefix", 3)
@@ -3553,7 +3553,7 @@ BOOST_FIXTURE_TEST_CASE( setparams, eosio_system_tester ) try {
       abi_serializer::from_variant(pretty_trx, trx, get_resolver(), abi_serializer::create_yield_function(abi_serializer_max_time));
    }
 
-   BOOST_REQUIRE_EQUAL(success(), push_action_msig( N(alice1111111), N(propose), mvo()
+   BOOST_REQUIRE_EQUAL(success(), push_action_msig( "alice1111111"_n, "propose"_n, mvo()
                                                     ("proposer",      "alice1111111")
                                                     ("proposal_name", "setparams1")
                                                     ("trx",           trx)
@@ -3563,7 +3563,7 @@ BOOST_FIXTURE_TEST_CASE( setparams, eosio_system_tester ) try {
 
    // get 16 approvals
    for ( size_t i = 0; i < 15; ++i ) {
-      BOOST_REQUIRE_EQUAL(success(), push_action_msig( name(producer_names[i]), N(approve), mvo()
+      BOOST_REQUIRE_EQUAL(success(), push_action_msig( name(producer_names[i]), "approve"_n, mvo()
                                                        ("proposer",      "alice1111111")
                                                        ("proposal_name", "setparams1")
                                                        ("level",         permission_level{ name(producer_names[i]), config::active_name })
@@ -3578,7 +3578,7 @@ BOOST_FIXTURE_TEST_CASE( setparams, eosio_system_tester ) try {
       if( t->scheduled ) { trace = t; }
    } );
 
-   BOOST_REQUIRE_EQUAL(success(), push_action_msig( N(alice1111111), N(exec), mvo()
+   BOOST_REQUIRE_EQUAL(success(), push_action_msig( "alice1111111"_n, "exec"_n, mvo()
                                                     ("proposer",      "alice1111111")
                                                     ("proposal_name", "setparams1")
                                                     ("executer",      "alice1111111")
@@ -3609,11 +3609,11 @@ BOOST_FIXTURE_TEST_CASE( wasmcfg, eosio_system_tester ) try {
          string action_type_name = msig_abi_ser.get_action_type(name);
 
          action act;
-         act.account = N(eosio.msig);
+         act.account = "eosio.msig"_n;
          act.name = name;
          act.data = msig_abi_ser.variant_to_binary( action_type_name, data, abi_serializer::create_yield_function(abi_serializer_max_time) );
 
-         return base_tester::push_action( std::move(act), (auth ? signer : signer == N(bob111111111) ? N(alice1111111) : N(bob111111111)).to_uint64_t() );
+         return base_tester::push_action( std::move(act), (auth ? signer : signer == "bob111111111"_n ? "alice1111111"_n : "bob111111111"_n).to_uint64_t() );
    };
 
    // test begins
@@ -3624,7 +3624,7 @@ BOOST_FIXTURE_TEST_CASE( wasmcfg, eosio_system_tester ) try {
 
    transaction trx;
    {
-      variant pretty_trx = fc::mutable_variant_object()
+      fc::variant pretty_trx = fc::mutable_variant_object()
          ("expiration", "2020-01-01T00:30")
          ("ref_block_num", 2)
          ("ref_block_prefix", 3)
@@ -3644,7 +3644,7 @@ BOOST_FIXTURE_TEST_CASE( wasmcfg, eosio_system_tester ) try {
       abi_serializer::from_variant(pretty_trx, trx, get_resolver(), abi_serializer::create_yield_function(abi_serializer_max_time));
    }
 
-   BOOST_REQUIRE_EQUAL(success(), push_action_msig( N(alice1111111), N(propose), mvo()
+   BOOST_REQUIRE_EQUAL(success(), push_action_msig( "alice1111111"_n, "propose"_n, mvo()
                                                     ("proposer",      "alice1111111")
                                                     ("proposal_name", "setparams1")
                                                     ("trx",           trx)
@@ -3654,7 +3654,7 @@ BOOST_FIXTURE_TEST_CASE( wasmcfg, eosio_system_tester ) try {
 
    // get 16 approvals
    for ( size_t i = 0; i < 15; ++i ) {
-      BOOST_REQUIRE_EQUAL(success(), push_action_msig( name(producer_names[i]), N(approve), mvo()
+      BOOST_REQUIRE_EQUAL(success(), push_action_msig( name(producer_names[i]), "approve"_n, mvo()
                                                        ("proposer",      "alice1111111")
                                                        ("proposal_name", "setparams1")
                                                        ("level",         permission_level{ name(producer_names[i]), config::active_name })
@@ -3669,7 +3669,7 @@ BOOST_FIXTURE_TEST_CASE( wasmcfg, eosio_system_tester ) try {
       if( t->scheduled ) { trace = t; }
    } );
 
-   BOOST_REQUIRE_EQUAL(success(), push_action_msig( N(alice1111111), N(exec), mvo()
+   BOOST_REQUIRE_EQUAL(success(), push_action_msig( "alice1111111"_n, "exec"_n, mvo()
                                                     ("proposer",      "alice1111111")
                                                     ("proposal_name", "setparams1")
                                                     ("executer",      "alice1111111")
@@ -3691,7 +3691,7 @@ BOOST_FIXTURE_TEST_CASE( setram_effect, eosio_system_tester ) try {
 
    const asset net = core_sym::from_string("8.0000");
    const asset cpu = core_sym::from_string("8.0000");
-   std::vector<account_name> accounts = { N(aliceaccount), N(bobbyaccount) };
+   std::vector<account_name> accounts = { "aliceaccount"_n, "bobbyaccount"_n };
    for (const auto& a: accounts) {
       create_account_with_resources(a, config::system_account_name, core_sym::from_string("1.0000"), false, net, cpu);
    }
@@ -3722,11 +3722,11 @@ BOOST_FIXTURE_TEST_CASE( setram_effect, eosio_system_tester ) try {
 
       // increase max_ram_size, ram bought by name_b loses part of its value
       BOOST_REQUIRE_EQUAL( wasm_assert_msg("ram may only be increased"),
-                           push_action(config::system_account_name, N(setram), mvo()("max_ram_size", 64ll*1024 * 1024 * 1024)) );
+                           push_action(config::system_account_name, "setram"_n, mvo()("max_ram_size", 64ll*1024 * 1024 * 1024)) );
       BOOST_REQUIRE_EQUAL( error("missing authority of eosio"),
-                           push_action(name_b, N(setram), mvo()("max_ram_size", 80ll*1024 * 1024 * 1024)) );
+                           push_action(name_b, "setram"_n, mvo()("max_ram_size", 80ll*1024 * 1024 * 1024)) );
       BOOST_REQUIRE_EQUAL( success(),
-                           push_action(config::system_account_name, N(setram), mvo()("max_ram_size", 80ll*1024 * 1024 * 1024)) );
+                           push_action(config::system_account_name, "setram"_n, mvo()("max_ram_size", 80ll*1024 * 1024 * 1024)) );
 
       BOOST_REQUIRE_EQUAL( success(), sellram(name_b, bought_bytes_b ) );
       BOOST_REQUIRE( core_sym::from_string("900.0000") < get_balance(name_b) );
@@ -3747,7 +3747,7 @@ BOOST_FIXTURE_TEST_CASE( ram_inflation, eosio_system_tester ) try {
    produce_blocks(3);
    BOOST_REQUIRE_EQUAL( init_max_ram_size, get_global_state()["max_ram_size"].as_uint64() );
    uint16_t rate = 1000;
-   BOOST_REQUIRE_EQUAL( success(), push_action( config::system_account_name, N(setramrate), mvo()("bytes_per_block", rate) ) );
+   BOOST_REQUIRE_EQUAL( success(), push_action( config::system_account_name, "setramrate"_n, mvo()("bytes_per_block", rate) ) );
    BOOST_REQUIRE_EQUAL( rate, get_global_state2()["new_ram_per_block"].as<uint16_t>() );
    // last time update_ram_supply called is in buyram, num of blocks since then to
    // the block that includes the setramrate action is 1 + 3 = 4.
@@ -3769,13 +3769,13 @@ BOOST_FIXTURE_TEST_CASE( ram_inflation, eosio_system_tester ) try {
    BOOST_REQUIRE_EQUAL( cur_ram_size + 2 * rate, get_global_state()["max_ram_size"].as_uint64() );
 
    BOOST_REQUIRE_EQUAL( error("missing authority of eosio"),
-                        push_action( N(alice1111111), N(setramrate), mvo()("bytes_per_block", rate) ) );
+                        push_action( "alice1111111"_n, "setramrate"_n, mvo()("bytes_per_block", rate) ) );
 
    cur_ram_size = get_global_state()["max_ram_size"].as_uint64();
    produce_blocks(10);
    uint16_t old_rate = rate;
    rate = 5000;
-   BOOST_REQUIRE_EQUAL( success(), push_action( config::system_account_name, N(setramrate), mvo()("bytes_per_block", rate) ) );
+   BOOST_REQUIRE_EQUAL( success(), push_action( config::system_account_name, "setramrate"_n, mvo()("bytes_per_block", rate) ) );
    BOOST_REQUIRE_EQUAL( cur_ram_size + 11 * old_rate, get_global_state()["max_ram_size"].as_uint64() );
    produce_blocks(5);
    BOOST_REQUIRE_EQUAL( success(), buyrambytes( "alice1111111", "alice1111111", 100 ) );
@@ -3788,28 +3788,28 @@ BOOST_FIXTURE_TEST_CASE( eosioram_ramusage, eosio_system_tester ) try {
    transfer( "eosio", "alice1111111", core_sym::from_string("1000.0000"), "eosio" );
    BOOST_REQUIRE_EQUAL( success(), stake( "eosio", "alice1111111", core_sym::from_string("200.0000"), core_sym::from_string("100.0000") ) );
 
-   const asset initial_ram_balance = get_balance(N(eosio.ram));
-   const asset initial_ramfee_balance = get_balance(N(eosio.ramfee));
+   const asset initial_ram_balance = get_balance("eosio.ram"_n);
+   const asset initial_ramfee_balance = get_balance("eosio.ramfee"_n);
    BOOST_REQUIRE_EQUAL( success(), buyram( "alice1111111", "alice1111111", core_sym::from_string("1000.0000") ) );
 
-   BOOST_REQUIRE_EQUAL( false, get_row_by_account( N(eosio.token), N(alice1111111), N(accounts), account_name(symbol{CORE_SYM}.to_symbol_code()) ).empty() );
+   BOOST_REQUIRE_EQUAL( false, get_row_by_account( "eosio.token"_n, "alice1111111"_n, "accounts"_n, account_name(symbol{CORE_SYM}.to_symbol_code()) ).empty() );
 
    //remove row
-   base_tester::push_action( N(eosio.token), N(close), N(alice1111111), mvo()
+   base_tester::push_action( "eosio.token"_n, "close"_n, "alice1111111"_n, mvo()
                              ( "owner", "alice1111111" )
                              ( "symbol", symbol{CORE_SYM} )
    );
-   BOOST_REQUIRE_EQUAL( true, get_row_by_account( N(eosio.token), N(alice1111111), N(accounts), account_name(symbol{CORE_SYM}.to_symbol_code()) ).empty() );
+   BOOST_REQUIRE_EQUAL( true, get_row_by_account( "eosio.token"_n, "alice1111111"_n, "accounts"_n, account_name(symbol{CORE_SYM}.to_symbol_code()) ).empty() );
 
    auto rlm = control->get_resource_limits_manager();
-   auto eosioram_ram_usage = rlm.get_account_ram_usage(N(eosio.ram));
-   auto alice_ram_usage = rlm.get_account_ram_usage(N(alice1111111));
+   auto eosioram_ram_usage = rlm.get_account_ram_usage("eosio.ram"_n);
+   auto alice_ram_usage = rlm.get_account_ram_usage("alice1111111"_n);
 
    BOOST_REQUIRE_EQUAL( success(), sellram( "alice1111111", 2048 ) );
 
    //make sure that ram was billed to alice, not to eosio.ram
-   BOOST_REQUIRE_EQUAL( true, alice_ram_usage < rlm.get_account_ram_usage(N(alice1111111)) );
-   BOOST_REQUIRE_EQUAL( eosioram_ram_usage, rlm.get_account_ram_usage(N(eosio.ram)) );
+   BOOST_REQUIRE_EQUAL( true, alice_ram_usage < rlm.get_account_ram_usage("alice1111111"_n) );
+   BOOST_REQUIRE_EQUAL( eosioram_ram_usage, rlm.get_account_ram_usage("eosio.ram"_n) );
 
 } FC_LOG_AND_RETHROW()
 
@@ -3818,16 +3818,16 @@ BOOST_FIXTURE_TEST_CASE( ram_gift, eosio_system_tester ) try {
 
    auto rlm = control->get_resource_limits_manager();
    int64_t ram_bytes_orig, net_weight, cpu_weight;
-   rlm.get_account_limits( N(alice1111111), ram_bytes_orig, net_weight, cpu_weight );
+   rlm.get_account_limits( "alice1111111"_n, ram_bytes_orig, net_weight, cpu_weight );
 
    /*
     * It seems impossible to write this test, because buyrambytes action doesn't give you exact amount of bytes requested
     *
    //check that it's possible to create account bying required_bytes(2724) + userres table(112) + userres row(160) - ram_gift_bytes(1400)
-   create_account_with_resources( N(abcdefghklmn), N(alice1111111), 2724 + 112 + 160 - 1400 );
+   create_account_with_resources( "abcdefghklmn"_n, "alice1111111"_n, 2724 + 112 + 160 - 1400 );
 
    //check that one byte less is not enough
-   BOOST_REQUIRE_THROW( create_account_with_resources( N(abcdefghklmn), N(alice1111111), 2724 + 112 + 160 - 1400 - 1 ),
+   BOOST_REQUIRE_THROW( create_account_with_resources( "abcdefghklmn"_n, "alice1111111"_n, 2724 + 112 + 160 - 1400 - 1 ),
                         ram_usage_exceeded );
    */
 
@@ -3835,34 +3835,34 @@ BOOST_FIXTURE_TEST_CASE( ram_gift, eosio_system_tester ) try {
    transfer( "eosio", "alice1111111", core_sym::from_string("1000.0000"), "eosio" );
    BOOST_REQUIRE_EQUAL( success(), stake( "eosio", "alice1111111", core_sym::from_string("200.0000"), core_sym::from_string("100.0000") ) );
    int64_t ram_bytes_after_stake;
-   rlm.get_account_limits( N(alice1111111), ram_bytes_after_stake, net_weight, cpu_weight );
+   rlm.get_account_limits( "alice1111111"_n, ram_bytes_after_stake, net_weight, cpu_weight );
    BOOST_REQUIRE_EQUAL( ram_bytes_orig, ram_bytes_after_stake );
 
    BOOST_REQUIRE_EQUAL( success(), unstake( "eosio", "alice1111111", core_sym::from_string("20.0000"), core_sym::from_string("10.0000") ) );
    int64_t ram_bytes_after_unstake;
-   rlm.get_account_limits( N(alice1111111), ram_bytes_after_unstake, net_weight, cpu_weight );
+   rlm.get_account_limits( "alice1111111"_n, ram_bytes_after_unstake, net_weight, cpu_weight );
    BOOST_REQUIRE_EQUAL( ram_bytes_orig, ram_bytes_after_unstake );
 
    uint64_t ram_gift = 1400;
 
    int64_t ram_bytes;
    BOOST_REQUIRE_EQUAL( success(), buyram( "alice1111111", "alice1111111", core_sym::from_string("1000.0000") ) );
-   rlm.get_account_limits( N(alice1111111), ram_bytes, net_weight, cpu_weight );
-   auto userres = get_total_stake( N(alice1111111) );
+   rlm.get_account_limits( "alice1111111"_n, ram_bytes, net_weight, cpu_weight );
+   auto userres = get_total_stake( "alice1111111"_n );
    BOOST_REQUIRE_EQUAL( userres["ram_bytes"].as_uint64() + ram_gift, ram_bytes );
 
    BOOST_REQUIRE_EQUAL( success(), sellram( "alice1111111", 1024 ) );
-   rlm.get_account_limits( N(alice1111111), ram_bytes, net_weight, cpu_weight );
-   userres = get_total_stake( N(alice1111111) );
+   rlm.get_account_limits( "alice1111111"_n, ram_bytes, net_weight, cpu_weight );
+   userres = get_total_stake( "alice1111111"_n );
    BOOST_REQUIRE_EQUAL( userres["ram_bytes"].as_uint64() + ram_gift, ram_bytes );
 
 } FC_LOG_AND_RETHROW()
 
 BOOST_FIXTURE_TEST_CASE( rex_rounding_issue, eosio_system_tester ) try {
-   const std::vector<name> whales { N(whale1), N(whale2), N(whale3), N(whale4) , N(whale5)  };
-   const name bob{ N(bob) }, alice{ N(alice) };
+   const std::vector<name> whales { "whale1"_n, "whale2"_n, "whale3"_n, "whale4"_n , "whale5"_n  };
+   const name bob{ "bob"_n }, alice{ "alice"_n };
    const std::vector<name> accounts = {bob, alice};
-   const std::vector<name> rexborrowers = {N(rex1), N(rex2), N(rex3), N(rex4)};
+   const std::vector<name> rexborrowers = {"rex1"_n, "rex2"_n, "rex3"_n, "rex4"_n};
     const asset one_eos      = core_sym::from_string("1.0000");
    const asset one_rex      = asset::from_string("1.0000 REX");
    const asset init_balance = core_sym::from_string("1000.0000");
@@ -3874,9 +3874,9 @@ BOOST_FIXTURE_TEST_CASE( rex_rounding_issue, eosio_system_tester ) try {
       create_accounts_with_resources({ w });
       stake_with_transfer(config::system_account_name, w, core_sym::from_string("1000.0000"), core_sym::from_string("1000.0000"));
       issue_and_transfer(w, core_sym::from_string("100000000.0000"));
-      BOOST_REQUIRE_EQUAL( success(), vote( w, { }, N(proxyaccount) ) );
-      BOOST_REQUIRE_EQUAL( success(), push_action( w, N(deposit), mvo()("owner", w)("amount", core_sym::from_string("1000000.0000")) ) );
-      BOOST_REQUIRE_EQUAL( success(), push_action( w, N(buyrex), mvo()("from", w)("amount", core_sym::from_string("1000000.0000")) ) );
+      BOOST_REQUIRE_EQUAL( success(), vote( w, { }, "proxyaccount"_n ) );
+      BOOST_REQUIRE_EQUAL( success(), push_action( w, "deposit"_n, mvo()("owner", w)("amount", core_sym::from_string("1000000.0000")) ) );
+      BOOST_REQUIRE_EQUAL( success(), push_action( w, "buyrex"_n, mvo()("from", w)("amount", core_sym::from_string("1000000.0000")) ) );
    }
 
    issue_and_transfer(bob, init_balance);
@@ -3887,22 +3887,22 @@ BOOST_FIXTURE_TEST_CASE( rex_rounding_issue, eosio_system_tester ) try {
       buyram(config::system_account_name, rb, core_sym::from_string("10.0000"));
       issue_and_transfer(rb, core_sym::from_string("1000000.0000"));
       stake_with_transfer(config::system_account_name, rb, core_sym::from_string("1000.0000"), core_sym::from_string("1000.0000"));
-      BOOST_REQUIRE_EQUAL( success(), vote( rb, { }, N(proxyaccount) ) );
-      BOOST_REQUIRE_EQUAL( success(), push_action( rb, N(deposit), mvo()("owner", rb)("amount", core_sym::from_string("1000000.0000")) ) );
+      BOOST_REQUIRE_EQUAL( success(), vote( rb, { }, "proxyaccount"_n ) );
+      BOOST_REQUIRE_EQUAL( success(), push_action( rb, "deposit"_n, mvo()("owner", rb)("amount", core_sym::from_string("1000000.0000")) ) );
    }
    // get accounts into rex
    for(auto& acct : accounts){
       stake_with_transfer(config::system_account_name, acct, core_sym::from_string("1000.0000"), core_sym::from_string("1000.0000"));
       issue_and_transfer(acct, core_sym::from_string("100.1239"));
-      BOOST_REQUIRE_EQUAL( success(), vote( acct, { }, N(proxyaccount) ) );
-      BOOST_REQUIRE_EQUAL( success(), push_action( acct, N(deposit), mvo()("owner", acct)("amount", core_sym::from_string("100.1239")) ) );
-      BOOST_REQUIRE_EQUAL( success(), push_action( acct, N(buyrex), mvo()("from", acct)("amount", core_sym::from_string("100.1239")) ) );
+      BOOST_REQUIRE_EQUAL( success(), vote( acct, { }, "proxyaccount"_n ) );
+      BOOST_REQUIRE_EQUAL( success(), push_action( acct, "deposit"_n, mvo()("owner", acct)("amount", core_sym::from_string("100.1239")) ) );
+      BOOST_REQUIRE_EQUAL( success(), push_action( acct, "buyrex"_n, mvo()("from", acct)("amount", core_sym::from_string("100.1239")) ) );
    }
 
    auto rent_and_go = [&] (int cnt) {
       for(auto& rb : rexborrowers) {
          BOOST_REQUIRE_EQUAL( success(),
-                        push_action( rb, N(rentcpu), 
+                        push_action( rb, "rentcpu"_n, 
                         mvo()
                         ("from", rb)
                         ("receiver", rb)
@@ -3912,12 +3912,12 @@ BOOST_FIXTURE_TEST_CASE( rex_rounding_issue, eosio_system_tester ) try {
       // exec and update
       for(auto& acct : accounts) {
          if(cnt % 10 == 0) {
-            BOOST_REQUIRE_EQUAL( success(), push_action( acct, N(rexexec), mvo()("user", acct)("max", 2) ) );
-            BOOST_REQUIRE_EQUAL( success(), push_action( acct, N(updaterex), mvo()("owner", acct) ) );
+            BOOST_REQUIRE_EQUAL( success(), push_action( acct, "rexexec"_n, mvo()("user", acct)("max", 2) ) );
+            BOOST_REQUIRE_EQUAL( success(), push_action( acct, "updaterex"_n, mvo()("owner", acct) ) );
          }
-         BOOST_REQUIRE_EQUAL( success(), push_action( acct, N(sellrex), mvo()("from", acct)("rex",one_rex) ) );
+         BOOST_REQUIRE_EQUAL( success(), push_action( acct, "sellrex"_n, mvo()("from", acct)("rex",one_rex) ) );
          BOOST_REQUIRE_EQUAL( success(),
-                            push_action( acct, N(unstaketorex), mvo()("owner", acct)("receiver", acct)("from_net", one_eos)("from_cpu", one_eos) ) );
+                            push_action( acct, "unstaketorex"_n, mvo()("owner", acct)("receiver", acct)("from_net", one_eos)("from_cpu", one_eos) ) );
       }
 
       produce_block( fc::days(1) );
@@ -3957,7 +3957,7 @@ BOOST_FIXTURE_TEST_CASE( rex_rounding_issue, eosio_system_tester ) try {
    std::vector<name> delegates = {};
    for(auto& acct : accounts) {
       BOOST_REQUIRE_EQUAL( success(),
-                            push_action( acct, N(voteupdate), mvo()("voter_name", acct) ) );
+                            push_action( acct, "voteupdate"_n, mvo()("voter_name", acct) ) );
    }
    // check that values are equal
    for(auto& acct : accounts) {
@@ -3968,7 +3968,7 @@ BOOST_FIXTURE_TEST_CASE( rex_rounding_issue, eosio_system_tester ) try {
 
 BOOST_FIXTURE_TEST_CASE( rex_auth, eosio_system_tester ) try {
 
-   const std::vector<account_name> accounts = { N(aliceaccount), N(bobbyaccount) };
+   const std::vector<account_name> accounts = { "aliceaccount"_n, "bobbyaccount"_n };
    const account_name alice = accounts[0], bob = accounts[1];
    const asset init_balance = core_sym::from_string("1000.0000");
    const asset one_eos      = core_sym::from_string("1.0000");
@@ -3976,29 +3976,29 @@ BOOST_FIXTURE_TEST_CASE( rex_auth, eosio_system_tester ) try {
    setup_rex_accounts( accounts, init_balance );
 
    const std::string error_msg("missing authority of aliceaccount");
-   BOOST_REQUIRE_EQUAL( error(error_msg), push_action( bob, N(deposit), mvo()("owner", alice)("amount", one_eos) ) );
-   BOOST_REQUIRE_EQUAL( error(error_msg), push_action( bob, N(withdraw), mvo()("owner", alice)("amount", one_eos) ) );
-   BOOST_REQUIRE_EQUAL( error(error_msg), push_action( bob, N(buyrex), mvo()("from", alice)("amount", one_eos) ) );
+   BOOST_REQUIRE_EQUAL( error(error_msg), push_action( bob, "deposit"_n, mvo()("owner", alice)("amount", one_eos) ) );
+   BOOST_REQUIRE_EQUAL( error(error_msg), push_action( bob, "withdraw"_n, mvo()("owner", alice)("amount", one_eos) ) );
+   BOOST_REQUIRE_EQUAL( error(error_msg), push_action( bob, "buyrex"_n, mvo()("from", alice)("amount", one_eos) ) );
    BOOST_REQUIRE_EQUAL( error(error_msg),
-                        push_action( bob, N(unstaketorex), mvo()("owner", alice)("receiver", alice)("from_net", one_eos)("from_cpu", one_eos) ) );
-   BOOST_REQUIRE_EQUAL( error(error_msg), push_action( bob, N(sellrex), mvo()("from", alice)("rex", one_rex) ) );
-   BOOST_REQUIRE_EQUAL( error(error_msg), push_action( bob, N(cnclrexorder), mvo()("owner", alice) ) );
+                        push_action( bob, "unstaketorex"_n, mvo()("owner", alice)("receiver", alice)("from_net", one_eos)("from_cpu", one_eos) ) );
+   BOOST_REQUIRE_EQUAL( error(error_msg), push_action( bob, "sellrex"_n, mvo()("from", alice)("rex", one_rex) ) );
+   BOOST_REQUIRE_EQUAL( error(error_msg), push_action( bob, "cnclrexorder"_n, mvo()("owner", alice) ) );
    BOOST_REQUIRE_EQUAL( error(error_msg),
-                        push_action( bob, N(rentcpu), mvo()("from", alice)("receiver", alice)("loan_payment", one_eos)("loan_fund", one_eos) ) );
+                        push_action( bob, "rentcpu"_n, mvo()("from", alice)("receiver", alice)("loan_payment", one_eos)("loan_fund", one_eos) ) );
    BOOST_REQUIRE_EQUAL( error(error_msg),
-                        push_action( bob, N(rentnet), mvo()("from", alice)("receiver", alice)("loan_payment", one_eos)("loan_fund", one_eos) ) );
-   BOOST_REQUIRE_EQUAL( error(error_msg), push_action( bob, N(fundcpuloan), mvo()("from", alice)("loan_num", 1)("payment", one_eos) ) );
-   BOOST_REQUIRE_EQUAL( error(error_msg), push_action( bob, N(fundnetloan), mvo()("from", alice)("loan_num", 1)("payment", one_eos) ) );
-   BOOST_REQUIRE_EQUAL( error(error_msg), push_action( bob, N(defcpuloan), mvo()("from", alice)("loan_num", 1)("amount", one_eos) ) );
-   BOOST_REQUIRE_EQUAL( error(error_msg), push_action( bob, N(defnetloan), mvo()("from", alice)("loan_num", 1)("amount", one_eos) ) );
-   BOOST_REQUIRE_EQUAL( error(error_msg), push_action( bob, N(updaterex), mvo()("owner", alice) ) );
-   BOOST_REQUIRE_EQUAL( error(error_msg), push_action( bob, N(rexexec), mvo()("user", alice)("max", 1) ) );
-   BOOST_REQUIRE_EQUAL( error(error_msg), push_action( bob, N(consolidate), mvo()("owner", alice) ) );
-   BOOST_REQUIRE_EQUAL( error(error_msg), push_action( bob, N(mvtosavings), mvo()("owner", alice)("rex", one_rex) ) );
-   BOOST_REQUIRE_EQUAL( error(error_msg), push_action( bob, N(mvfrsavings), mvo()("owner", alice)("rex", one_rex) ) );
-   BOOST_REQUIRE_EQUAL( error(error_msg), push_action( bob, N(closerex), mvo()("owner", alice) ) );
+                        push_action( bob, "rentnet"_n, mvo()("from", alice)("receiver", alice)("loan_payment", one_eos)("loan_fund", one_eos) ) );
+   BOOST_REQUIRE_EQUAL( error(error_msg), push_action( bob, "fundcpuloan"_n, mvo()("from", alice)("loan_num", 1)("payment", one_eos) ) );
+   BOOST_REQUIRE_EQUAL( error(error_msg), push_action( bob, "fundnetloan"_n, mvo()("from", alice)("loan_num", 1)("payment", one_eos) ) );
+   BOOST_REQUIRE_EQUAL( error(error_msg), push_action( bob, "defcpuloan"_n, mvo()("from", alice)("loan_num", 1)("amount", one_eos) ) );
+   BOOST_REQUIRE_EQUAL( error(error_msg), push_action( bob, "defnetloan"_n, mvo()("from", alice)("loan_num", 1)("amount", one_eos) ) );
+   BOOST_REQUIRE_EQUAL( error(error_msg), push_action( bob, "updaterex"_n, mvo()("owner", alice) ) );
+   BOOST_REQUIRE_EQUAL( error(error_msg), push_action( bob, "rexexec"_n, mvo()("user", alice)("max", 1) ) );
+   BOOST_REQUIRE_EQUAL( error(error_msg), push_action( bob, "consolidate"_n, mvo()("owner", alice) ) );
+   BOOST_REQUIRE_EQUAL( error(error_msg), push_action( bob, "mvtosavings"_n, mvo()("owner", alice)("rex", one_rex) ) );
+   BOOST_REQUIRE_EQUAL( error(error_msg), push_action( bob, "mvfrsavings"_n, mvo()("owner", alice)("rex", one_rex) ) );
+   BOOST_REQUIRE_EQUAL( error(error_msg), push_action( bob, "closerex"_n, mvo()("owner", alice) ) );
 
-   BOOST_REQUIRE_EQUAL( error("missing authority of eosio"), push_action( alice, N(setrex), mvo()("balance", one_eos) ) );
+   BOOST_REQUIRE_EQUAL( error("missing authority of eosio"), push_action( alice, "setrex"_n, mvo()("balance", one_eos) ) );
 
 } FC_LOG_AND_RETHROW()
 
@@ -4008,7 +4008,7 @@ BOOST_FIXTURE_TEST_CASE( buy_sell_rex, eosio_system_tester ) try {
    const int64_t ratio        = 10000;
    const asset   init_rent    = core_sym::from_string("20000.0000");
    const asset   init_balance = core_sym::from_string("1000.0000");
-   const std::vector<account_name> accounts = { N(aliceaccount), N(bobbyaccount), N(carolaccount), N(emilyaccount), N(frankaccount) };
+   const std::vector<account_name> accounts = { "aliceaccount"_n, "bobbyaccount"_n, "carolaccount"_n, "emilyaccount"_n, "frankaccount"_n };
    account_name alice = accounts[0], bob = accounts[1], carol = accounts[2], emily = accounts[3], frank = accounts[4];
    setup_rex_accounts( accounts, init_balance );
 
@@ -4070,7 +4070,7 @@ BOOST_FIXTURE_TEST_CASE( buy_sell_small_rex, eosio_system_tester ) try {
 
    const int64_t ratio        = 10000;
    const asset   init_balance = core_sym::from_string("50000.0000");
-   const std::vector<account_name> accounts = { N(aliceaccount), N(bobbyaccount), N(carolaccount) };
+   const std::vector<account_name> accounts = { "aliceaccount"_n, "bobbyaccount"_n, "carolaccount"_n };
    account_name alice = accounts[0], bob = accounts[1], carol = accounts[2];
    setup_rex_accounts( accounts, init_balance );
 
@@ -4106,7 +4106,7 @@ BOOST_FIXTURE_TEST_CASE( unstake_buy_rex, eosio_system_tester, * boost::unit_tes
    const asset   init_balance = core_sym::from_string("10000.0000");
    const asset   init_net     = core_sym::from_string("70.0000");
    const asset   init_cpu     = core_sym::from_string("90.0000");
-   const std::vector<account_name> accounts = { N(aliceaccount), N(bobbyaccount), N(carolaccount), N(emilyaccount), N(frankaccount) };
+   const std::vector<account_name> accounts = { "aliceaccount"_n, "bobbyaccount"_n, "carolaccount"_n, "emilyaccount"_n, "frankaccount"_n };
    account_name alice = accounts[0], bob = accounts[1], carol = accounts[2], emily = accounts[3], frank = accounts[4];
    setup_rex_accounts( accounts, init_balance, init_net, init_cpu, false );
 
@@ -4143,7 +4143,7 @@ BOOST_FIXTURE_TEST_CASE( unstake_buy_rex, eosio_system_tester, * boost::unit_tes
                            unstaketorex( alice, alice, net_stake, cpu_stake ) );
       BOOST_REQUIRE_EQUAL( success(),
                            vote( alice, std::vector<account_name>(producer_names.begin(), producer_names.begin() + 21) ) );
-      const asset init_eosio_stake_balance = get_balance( N(eosio.stake) );
+      const asset init_eosio_stake_balance = get_balance( "eosio.stake"_n );
       const auto init_voter_info = get_voter_info( alice );
       const auto init_prod_info  = get_producer_info( producer_names[0] );
       BOOST_TEST_REQUIRE( init_prod_info["total_votes"].as_double() ==
@@ -4154,8 +4154,8 @@ BOOST_FIXTURE_TEST_CASE( unstake_buy_rex, eosio_system_tester, * boost::unit_tes
       BOOST_REQUIRE_EQUAL( get_net_limit( alice ),                  init_net_limit );
       BOOST_REQUIRE_EQUAL( ratio * tot_stake.get_amount(),          get_rex_balance( alice ).get_amount() );
       BOOST_REQUIRE_EQUAL( tot_stake,                               get_rex_balance_obj( alice )["vote_stake"].as<asset>() );
-      BOOST_REQUIRE_EQUAL( tot_stake,                               get_balance( N(eosio.rex) ) );
-      BOOST_REQUIRE_EQUAL( tot_stake,                               init_eosio_stake_balance - get_balance( N(eosio.stake) ) );
+      BOOST_REQUIRE_EQUAL( tot_stake,                               get_balance( "eosio.rex"_n ) );
+      BOOST_REQUIRE_EQUAL( tot_stake,                               init_eosio_stake_balance - get_balance( "eosio.stake"_n ) );
       auto current_voter_info = get_voter_info( alice );
       auto current_prod_info  = get_producer_info( producer_names[0] );
       BOOST_REQUIRE_EQUAL( init_voter_info["staked"].as<int64_t>(), current_voter_info["staked"].as<int64_t>() );
@@ -4219,7 +4219,7 @@ BOOST_FIXTURE_TEST_CASE( buy_rent_rex, eosio_system_tester ) try {
    const asset   init_balance = core_sym::from_string("60000.0000");
    const asset   init_net     = core_sym::from_string("70.0000");
    const asset   init_cpu     = core_sym::from_string("90.0000");
-   const std::vector<account_name> accounts = { N(aliceaccount), N(bobbyaccount), N(carolaccount), N(emilyaccount), N(frankaccount) };
+   const std::vector<account_name> accounts = { "aliceaccount"_n, "bobbyaccount"_n, "carolaccount"_n, "emilyaccount"_n, "frankaccount"_n };
    account_name alice = accounts[0], bob = accounts[1], carol = accounts[2], emily = accounts[3], frank = accounts[4];
    setup_rex_accounts( accounts, init_balance, init_net, init_cpu );
 
@@ -4319,7 +4319,7 @@ BOOST_FIXTURE_TEST_CASE( buy_sell_sell_rex, eosio_system_tester ) try {
    const asset   init_balance = core_sym::from_string("40000.0000");
    const asset   init_net     = core_sym::from_string("70.0000");
    const asset   init_cpu     = core_sym::from_string("90.0000");
-   const std::vector<account_name> accounts = { N(aliceaccount), N(bobbyaccount), N(carolaccount) };
+   const std::vector<account_name> accounts = { "aliceaccount"_n, "bobbyaccount"_n, "carolaccount"_n };
    account_name alice = accounts[0], bob = accounts[1], carol = accounts[2];
    setup_rex_accounts( accounts, init_balance, init_net, init_cpu );
 
@@ -4376,7 +4376,7 @@ BOOST_FIXTURE_TEST_CASE( buy_sell_sell_rex, eosio_system_tester ) try {
 BOOST_FIXTURE_TEST_CASE( buy_sell_claim_rex, eosio_system_tester ) try {
 
    const asset init_balance = core_sym::from_string("3000000.0000");
-   const std::vector<account_name> accounts = { N(aliceaccount), N(bobbyaccount), N(carolaccount), N(emilyaccount), N(frankaccount) };
+   const std::vector<account_name> accounts = { "aliceaccount"_n, "bobbyaccount"_n, "carolaccount"_n, "emilyaccount"_n, "frankaccount"_n };
    account_name alice = accounts[0], bob = accounts[1], carol = accounts[2], emily = accounts[3], frank = accounts[4];
    setup_rex_accounts( accounts, init_balance );
 
@@ -4457,7 +4457,7 @@ BOOST_FIXTURE_TEST_CASE( buy_sell_claim_rex, eosio_system_tester ) try {
    BOOST_REQUIRE_EQUAL( wasm_assert_msg("rex loans are currently not available"),
                         rentcpu( frank, frank, core_sym::from_string("0.0001") ) );
    {
-      auto trace = base_tester::push_action( config::system_account_name, N(rexexec), frank,
+      auto trace = base_tester::push_action( config::system_account_name, "rexexec"_n, frank,
                                              mvo()("user", frank)("max", 2) );
       auto output = get_rexorder_result( trace );
       BOOST_REQUIRE_EQUAL( output.size(),    1 );
@@ -4489,8 +4489,8 @@ BOOST_FIXTURE_TEST_CASE( buy_sell_claim_rex, eosio_system_tester ) try {
    produce_blocks(2);
 
    {
-      auto trace1 = base_tester::push_action( config::system_account_name, N(updaterex), bob, mvo()("owner", bob) );
-      auto trace2 = base_tester::push_action( config::system_account_name, N(updaterex), carol, mvo()("owner", carol) );
+      auto trace1 = base_tester::push_action( config::system_account_name, "updaterex"_n, bob, mvo()("owner", bob) );
+      auto trace2 = base_tester::push_action( config::system_account_name, "updaterex"_n, carol, mvo()("owner", carol) );
       BOOST_REQUIRE_EQUAL( 0,              get_rex_vote_stake( bob ).get_amount() );
       BOOST_REQUIRE_EQUAL( init_stake,     get_voter_info( bob )["staked"].as<int64_t>() );
       BOOST_REQUIRE_EQUAL( 0,              get_rex_vote_stake( carol ).get_amount() );
@@ -4525,7 +4525,7 @@ BOOST_FIXTURE_TEST_CASE( rex_loans, eosio_system_tester ) try {
    const int64_t ratio        = 10000;
    const asset   init_balance = core_sym::from_string("40000.0000");
    const asset   one_unit     = core_sym::from_string("0.0001");
-   const std::vector<account_name> accounts = { N(aliceaccount), N(bobbyaccount), N(carolaccount), N(emilyaccount), N(frankaccount) };
+   const std::vector<account_name> accounts = { "aliceaccount"_n, "bobbyaccount"_n, "carolaccount"_n, "emilyaccount"_n, "frankaccount"_n };
    account_name alice = accounts[0], bob = accounts[1], carol = accounts[2], emily = accounts[3], frank = accounts[4];
    setup_rex_accounts( accounts, init_balance  );
 
@@ -4664,7 +4664,7 @@ BOOST_FIXTURE_TEST_CASE( rex_loan_checks, eosio_system_tester ) try {
 
    const int64_t ratio        = 10000;
    const asset   init_balance = core_sym::from_string("40000.0000");
-   const std::vector<account_name> accounts = { N(aliceaccount), N(bobbyaccount) };
+   const std::vector<account_name> accounts = { "aliceaccount"_n, "bobbyaccount"_n };
    account_name alice = accounts[0], bob = accounts[1];
    setup_rex_accounts( accounts, init_balance );
 
@@ -4695,25 +4695,25 @@ BOOST_FIXTURE_TEST_CASE( ramfee_namebid_to_rex, eosio_system_tester ) try {
 
    const int64_t ratio        = 10000;
    const asset   init_balance = core_sym::from_string("10000.0000");
-   const std::vector<account_name> accounts = { N(aliceaccount), N(bobbyaccount), N(carolaccount), N(emilyaccount), N(frankaccount) };
+   const std::vector<account_name> accounts = { "aliceaccount"_n, "bobbyaccount"_n, "carolaccount"_n, "emilyaccount"_n, "frankaccount"_n };
    account_name alice = accounts[0], bob = accounts[1], carol = accounts[2], emily = accounts[3], frank = accounts[4];
    setup_rex_accounts( accounts, init_balance, core_sym::from_string("80.0000"), core_sym::from_string("80.0000"), false );
 
-   asset cur_ramfee_balance = get_balance( N(eosio.ramfee) );
+   asset cur_ramfee_balance = get_balance( "eosio.ramfee"_n );
    BOOST_REQUIRE_EQUAL( success(),                      buyram( alice, alice, core_sym::from_string("20.0000") ) );
-   BOOST_REQUIRE_EQUAL( get_balance( N(eosio.ramfee) ), core_sym::from_string("0.1000") + cur_ramfee_balance );
+   BOOST_REQUIRE_EQUAL( get_balance( "eosio.ramfee"_n ), core_sym::from_string("0.1000") + cur_ramfee_balance );
    BOOST_REQUIRE_EQUAL( wasm_assert_msg("must deposit to REX fund first"),
                         buyrex( alice, core_sym::from_string("350.0000") ) );
    BOOST_REQUIRE_EQUAL( success(),                      deposit( alice, core_sym::from_string("350.0000") ) );
    BOOST_REQUIRE_EQUAL( success(),                      buyrex( alice, core_sym::from_string("350.0000") ) );
-   cur_ramfee_balance = get_balance( N(eosio.ramfee) );
-   asset cur_rex_balance = get_balance( N(eosio.rex) );
+   cur_ramfee_balance = get_balance( "eosio.ramfee"_n );
+   asset cur_rex_balance = get_balance( "eosio.rex"_n );
    BOOST_REQUIRE_EQUAL( core_sym::from_string("350.0000"), cur_rex_balance );
    BOOST_REQUIRE_EQUAL( success(),                         buyram( bob, carol, core_sym::from_string("70.0000") ) );
-   BOOST_REQUIRE_EQUAL( cur_ramfee_balance,                get_balance( N(eosio.ramfee) ) );
-   BOOST_REQUIRE_EQUAL( get_balance( N(eosio.rex) ),       cur_rex_balance + core_sym::from_string("0.3500") );
+   BOOST_REQUIRE_EQUAL( cur_ramfee_balance,                get_balance( "eosio.ramfee"_n ) );
+   BOOST_REQUIRE_EQUAL( get_balance( "eosio.rex"_n ),       cur_rex_balance + core_sym::from_string("0.3500") );
 
-   cur_rex_balance = get_balance( N(eosio.rex) );
+   cur_rex_balance = get_balance( "eosio.rex"_n );
 
    produce_blocks( 1 );
    produce_block( fc::hours(30*24 + 12) );
@@ -4733,11 +4733,11 @@ BOOST_FIXTURE_TEST_CASE( ramfee_namebid_to_rex, eosio_system_tester ) try {
    cross_15_percent_threshold();
    produce_block( fc::days(14) );
 
-   cur_rex_balance = get_balance( N(eosio.rex) );
-   BOOST_REQUIRE_EQUAL( success(),                        bidname( carol, N(rndmbid), core_sym::from_string("23.7000") ) );
-   BOOST_REQUIRE_EQUAL( core_sym::from_string("23.7000"), get_balance( N(eosio.names) ) );
-   BOOST_REQUIRE_EQUAL( success(),                        bidname( alice, N(rndmbid), core_sym::from_string("29.3500") ) );
-   BOOST_REQUIRE_EQUAL( core_sym::from_string("29.3500"), get_balance( N(eosio.names) ));
+   cur_rex_balance = get_balance( "eosio.rex"_n );
+   BOOST_REQUIRE_EQUAL( success(),                        bidname( carol, "rndmbid"_n, core_sym::from_string("23.7000") ) );
+   BOOST_REQUIRE_EQUAL( core_sym::from_string("23.7000"), get_balance( "eosio.names"_n ) );
+   BOOST_REQUIRE_EQUAL( success(),                        bidname( alice, "rndmbid"_n, core_sym::from_string("29.3500") ) );
+   BOOST_REQUIRE_EQUAL( core_sym::from_string("29.3500"), get_balance( "eosio.names"_n ));
 
    produce_block( fc::hours(24) );
    produce_blocks( 2 );
@@ -4745,10 +4745,10 @@ BOOST_FIXTURE_TEST_CASE( ramfee_namebid_to_rex, eosio_system_tester ) try {
    BOOST_REQUIRE_EQUAL( core_sym::from_string("29.3500"), get_rex_pool()["namebid_proceeds"].as<asset>() );
    BOOST_REQUIRE_EQUAL( success(),                        deposit( frank, core_sym::from_string("5.0000") ) );
    BOOST_REQUIRE_EQUAL( success(),                        buyrex( frank, core_sym::from_string("5.0000") ) );
-   BOOST_REQUIRE_EQUAL( get_balance( N(eosio.rex) ),      cur_rex_balance + core_sym::from_string("34.3500") );
-   BOOST_REQUIRE_EQUAL( 0,                                get_balance( N(eosio.names) ).get_amount() );
+   BOOST_REQUIRE_EQUAL( get_balance( "eosio.rex"_n ),      cur_rex_balance + core_sym::from_string("34.3500") );
+   BOOST_REQUIRE_EQUAL( 0,                                get_balance( "eosio.names"_n ).get_amount() );
 
-   cur_rex_balance = get_balance( N(eosio.rex) );
+   cur_rex_balance = get_balance( "eosio.rex"_n );
    produce_block( fc::hours(30*24 + 13) );
    produce_blocks( 1 );
 
@@ -4763,7 +4763,7 @@ BOOST_FIXTURE_TEST_CASE( ramfee_namebid_to_rex, eosio_system_tester ) try {
 BOOST_FIXTURE_TEST_CASE( rex_maturity, eosio_system_tester ) try {
 
    const asset init_balance = core_sym::from_string("1000000.0000");
-   const std::vector<account_name> accounts = { N(aliceaccount), N(bobbyaccount) };
+   const std::vector<account_name> accounts = { "aliceaccount"_n, "bobbyaccount"_n };
    account_name alice = accounts[0], bob = accounts[1];
    setup_rex_accounts( accounts, init_balance );
 
@@ -4908,7 +4908,7 @@ BOOST_FIXTURE_TEST_CASE( rex_maturity, eosio_system_tester ) try {
 BOOST_FIXTURE_TEST_CASE( rex_savings, eosio_system_tester ) try {
 
    const asset init_balance = core_sym::from_string("100000.0000");
-   const std::vector<account_name> accounts = { N(aliceaccount), N(bobbyaccount), N(carolaccount), N(emilyaccount), N(frankaccount) };
+   const std::vector<account_name> accounts = { "aliceaccount"_n, "bobbyaccount"_n, "carolaccount"_n, "emilyaccount"_n, "frankaccount"_n };
    account_name alice = accounts[0], bob = accounts[1], carol = accounts[2], emily = accounts[3], frank = accounts[4];
    setup_rex_accounts( accounts, init_balance );
 
@@ -5125,7 +5125,7 @@ BOOST_FIXTURE_TEST_CASE( rex_savings, eosio_system_tester ) try {
 BOOST_FIXTURE_TEST_CASE( update_rex, eosio_system_tester, * boost::unit_test::tolerance(1e-10) ) try {
 
    const asset init_balance = core_sym::from_string("30000.0000");
-   const std::vector<account_name> accounts = { N(aliceaccount), N(bobbyaccount), N(carolaccount), N(emilyaccount) };
+   const std::vector<account_name> accounts = { "aliceaccount"_n, "bobbyaccount"_n, "carolaccount"_n, "emilyaccount"_n };
    account_name alice = accounts[0], bob = accounts[1], carol = accounts[2], emily = accounts[3];
    setup_rex_accounts( accounts, init_balance );
 
@@ -5224,7 +5224,7 @@ BOOST_FIXTURE_TEST_CASE( update_rex_vote, eosio_system_tester, * boost::unit_tes
    }
 
    const asset init_balance = core_sym::from_string("30000.0000");
-   const std::vector<account_name> accounts = { N(aliceaccount), N(bobbyaccount), N(carolaccount), N(emilyaccount) };
+   const std::vector<account_name> accounts = { "aliceaccount"_n, "bobbyaccount"_n, "carolaccount"_n, "emilyaccount"_n };
    account_name alice = accounts[0], bob = accounts[1], carol = accounts[2], emily = accounts[3];
    setup_rex_accounts( accounts, init_balance );
 
@@ -5286,7 +5286,7 @@ BOOST_FIXTURE_TEST_CASE( deposit_rex_fund, eosio_system_tester ) try {
    const asset init_balance = core_sym::from_string("1000.0000");
    const asset init_net     = core_sym::from_string("70.0000");
    const asset init_cpu     = core_sym::from_string("90.0000");
-   const std::vector<account_name> accounts = { N(aliceaccount), N(bobbyaccount) };
+   const std::vector<account_name> accounts = { "aliceaccount"_n, "bobbyaccount"_n };
    account_name alice = accounts[0], bob = accounts[1];
    setup_rex_accounts( accounts, init_balance, init_net, init_cpu, false );
 
@@ -5316,7 +5316,7 @@ BOOST_FIXTURE_TEST_CASE( deposit_rex_fund, eosio_system_tester ) try {
 BOOST_FIXTURE_TEST_CASE( rex_lower_bound, eosio_system_tester ) try {
 
    const asset init_balance = core_sym::from_string("25000.0000");
-   const std::vector<account_name> accounts = { N(aliceaccount), N(bobbyaccount) };
+   const std::vector<account_name> accounts = { "aliceaccount"_n, "bobbyaccount"_n };
    account_name alice = accounts[0], bob = accounts[1];
    setup_rex_accounts( accounts, init_balance );
    const symbol rex_sym( SY(4, REX) );
@@ -5347,7 +5347,7 @@ BOOST_FIXTURE_TEST_CASE( rex_lower_bound, eosio_system_tester ) try {
 BOOST_FIXTURE_TEST_CASE( close_rex, eosio_system_tester ) try {
 
    const asset init_balance = core_sym::from_string("25000.0000");
-   const std::vector<account_name> accounts = { N(aliceaccount), N(bobbyaccount), N(carolaccount), N(emilyaccount) };
+   const std::vector<account_name> accounts = { "aliceaccount"_n, "bobbyaccount"_n, "carolaccount"_n, "emilyaccount"_n };
    account_name alice = accounts[0], bob = accounts[1], carol = accounts[2], emily = accounts[3];
    setup_rex_accounts( accounts, init_balance );
 
@@ -5422,11 +5422,11 @@ BOOST_FIXTURE_TEST_CASE( close_rex, eosio_system_tester ) try {
 BOOST_FIXTURE_TEST_CASE( set_rex, eosio_system_tester ) try {
 
    const asset init_balance = core_sym::from_string("25000.0000");
-   const std::vector<account_name> accounts = { N(aliceaccount), N(bobbyaccount) };
+   const std::vector<account_name> accounts = { "aliceaccount"_n, "bobbyaccount"_n };
    account_name alice = accounts[0], bob = accounts[1];
    setup_rex_accounts( accounts, init_balance );
 
-   const name act_name{ N(setrex) };
+   const name act_name{ "setrex"_n };
    const asset init_total_rent  = core_sym::from_string("20000.0000");
    const asset set_total_rent   = core_sym::from_string("10000.0000");
    const asset negative_balance = core_sym::from_string("-10000.0000");
@@ -5467,11 +5467,11 @@ BOOST_FIXTURE_TEST_CASE( b1_vesting, eosio_system_tester ) try {
    produce_block( fc::days(14) );
 
    const asset init_balance = core_sym::from_string("25000.0000");
-   const std::vector<account_name> accounts = { N(aliceaccount), N(bobbyaccount) };
+   const std::vector<account_name> accounts = { "aliceaccount"_n, "bobbyaccount"_n };
    account_name alice = accounts[0], bob = accounts[1];
    setup_rex_accounts( accounts, init_balance );
 
-   const name b1{ N(b1) };
+   const name b1{ "b1"_n };
 
    issue_and_transfer( alice, core_sym::from_string("20000.0000"), config::system_account_name );
    issue_and_transfer( bob,   core_sym::from_string("20000.0000"), config::system_account_name );
@@ -5495,7 +5495,7 @@ BOOST_FIXTURE_TEST_CASE( b1_vesting, eosio_system_tester ) try {
 
    produce_block( fc::days(4) );
 
-   BOOST_REQUIRE_EQUAL( success(), push_action( b1, N(refund), mvo()("owner", b1) ) );
+   BOOST_REQUIRE_EQUAL( success(), push_action( b1, "refund"_n, mvo()("owner", b1) ) );
 
    BOOST_REQUIRE_EQUAL( 2 * ( stake_amount.get_amount() - small_amount.get_amount() ),
                         get_voter_info( b1 )["staked"].as<int64_t>() );
@@ -5506,13 +5506,13 @@ BOOST_FIXTURE_TEST_CASE( b1_vesting, eosio_system_tester ) try {
    BOOST_REQUIRE_EQUAL( wasm_assert_msg("must vote for at least 21 producers or for a proxy before buying REX"), 
                         unstaketorex( b1, b1, final_amount - small_amount, final_amount - small_amount ) );
 
-   BOOST_REQUIRE_EQUAL( error("missing authority of eosio"), vote( b1, { }, N(proxyaccount) ) );
+   BOOST_REQUIRE_EQUAL( error("missing authority of eosio"), vote( b1, { }, "proxyaccount"_n ) );
 
    BOOST_REQUIRE_EQUAL( success(), unstake( b1, b1, final_amount - small_amount, final_amount - small_amount ) );
    
    produce_block( fc::days(4) );
 
-   BOOST_REQUIRE_EQUAL( success(), push_action( b1, N(refund), mvo()("owner", b1) ) );
+   BOOST_REQUIRE_EQUAL( success(), push_action( b1, "refund"_n, mvo()("owner", b1) ) );
 
    produce_block( fc::days( 5 * 364 ) );
 
@@ -5529,7 +5529,7 @@ BOOST_FIXTURE_TEST_CASE( rex_return, eosio_system_tester ) try {
    BOOST_REQUIRE_EQUAL( true,                get_rex_return_pool().is_null() );
 
    const asset init_balance = core_sym::from_string("100000.0000");
-   const std::vector<account_name> accounts = { N(aliceaccount), N(bobbyaccount) };
+   const std::vector<account_name> accounts = { "aliceaccount"_n, "bobbyaccount"_n };
    account_name alice = accounts[0], bob = accounts[1];
    setup_rex_accounts( accounts, init_balance );
 
@@ -5694,10 +5694,10 @@ BOOST_AUTO_TEST_CASE( setabi_bios ) try {
    abi_serializer abi_ser(fc::json::from_string( (const char*)contracts::bios_abi().data()).template as<abi_def>(), abi_serializer::create_yield_function(base_tester::abi_serializer_max_time));
    t.set_code( config::system_account_name, contracts::bios_wasm() );
    t.set_abi( config::system_account_name, contracts::bios_abi().data() );
-   t.create_account(N(eosio.token));
-   t.set_abi( N(eosio.token), contracts::token_abi().data() );
+   t.create_account("eosio.token"_n);
+   t.set_abi( "eosio.token"_n, contracts::token_abi().data() );
    {
-      auto res = t.get_row_by_account( config::system_account_name, config::system_account_name, N(abihash), N(eosio.token) );
+      auto res = t.get_row_by_account( config::system_account_name, config::system_account_name, "abihash"_n, "eosio.token"_n );
       _abi_hash abi_hash;
       auto abi_hash_var = abi_ser.binary_to_variant( "abi_hash", res, abi_serializer::create_yield_function(base_tester::abi_serializer_max_time) );
       abi_serializer::from_variant( abi_hash_var, abi_hash, t.get_resolver(), abi_serializer::create_yield_function(base_tester::abi_serializer_max_time));
@@ -5707,9 +5707,9 @@ BOOST_AUTO_TEST_CASE( setabi_bios ) try {
       BOOST_REQUIRE( abi_hash.hash == result );
    }
 
-   t.set_abi( N(eosio.token), contracts::system_abi().data() );
+   t.set_abi( "eosio.token"_n, contracts::system_abi().data() );
    {
-      auto res = t.get_row_by_account( config::system_account_name, config::system_account_name, N(abihash), N(eosio.token) );
+      auto res = t.get_row_by_account( config::system_account_name, config::system_account_name, "abihash"_n, "eosio.token"_n );
       _abi_hash abi_hash;
       auto abi_hash_var = abi_ser.binary_to_variant( "abi_hash", res, abi_serializer::create_yield_function(base_tester::abi_serializer_max_time) );
       abi_serializer::from_variant( abi_hash_var, abi_hash, t.get_resolver(), abi_serializer::create_yield_function(base_tester::abi_serializer_max_time));
@@ -5721,9 +5721,9 @@ BOOST_AUTO_TEST_CASE( setabi_bios ) try {
 } FC_LOG_AND_RETHROW()
 
 BOOST_FIXTURE_TEST_CASE( setabi, eosio_system_tester ) try {
-   set_abi( N(eosio.token), contracts::token_abi().data() );
+   set_abi( "eosio.token"_n, contracts::token_abi().data() );
    {
-      auto res = get_row_by_account( config::system_account_name, config::system_account_name, N(abihash), N(eosio.token) );
+      auto res = get_row_by_account( config::system_account_name, config::system_account_name, "abihash"_n, "eosio.token"_n );
       _abi_hash abi_hash;
       auto abi_hash_var = abi_ser.binary_to_variant( "abi_hash", res, abi_serializer::create_yield_function(abi_serializer_max_time) );
       abi_serializer::from_variant( abi_hash_var, abi_hash, get_resolver(), abi_serializer::create_yield_function(abi_serializer_max_time));
@@ -5733,9 +5733,9 @@ BOOST_FIXTURE_TEST_CASE( setabi, eosio_system_tester ) try {
       BOOST_REQUIRE( abi_hash.hash == result );
    }
 
-   set_abi( N(eosio.token), contracts::system_abi().data() );
+   set_abi( "eosio.token"_n, contracts::system_abi().data() );
    {
-      auto res = get_row_by_account( config::system_account_name, config::system_account_name, N(abihash), N(eosio.token) );
+      auto res = get_row_by_account( config::system_account_name, config::system_account_name, "abihash"_n, "eosio.token"_n );
       _abi_hash abi_hash;
       auto abi_hash_var = abi_ser.binary_to_variant( "abi_hash", res, abi_serializer::create_yield_function(abi_serializer_max_time) );
       abi_serializer::from_variant( abi_hash_var, abi_hash, get_resolver(), abi_serializer::create_yield_function(abi_serializer_max_time));
@@ -5750,9 +5750,9 @@ BOOST_FIXTURE_TEST_CASE( setabi, eosio_system_tester ) try {
 BOOST_FIXTURE_TEST_CASE( change_limited_account_back_to_unlimited, eosio_system_tester ) try {
    BOOST_REQUIRE( get_total_stake( "eosio" ).is_null() );
 
-   transfer( N(eosio), N(alice1111111), core_sym::from_string("1.0000") );
+   transfer( "eosio"_n, "alice1111111"_n, core_sym::from_string("1.0000") );
 
-   auto error_msg = stake( N(alice1111111), N(eosio), core_sym::from_string("0.0000"), core_sym::from_string("1.0000") );
+   auto error_msg = stake( "alice1111111"_n, "eosio"_n, core_sym::from_string("0.0000"), core_sym::from_string("1.0000") );
    auto semicolon_pos = error_msg.find(';');
 
    BOOST_REQUIRE_EQUAL( error("account eosio has insufficient ram"),
@@ -5766,14 +5766,14 @@ BOOST_FIXTURE_TEST_CASE( change_limited_account_back_to_unlimited, eosio_system_
       ram_bytes_needed += 256; // enough room to cover total_resources_table
    }
 
-   push_action( N(eosio), N(setalimits), mvo()
+   push_action( "eosio"_n, "setalimits"_n, mvo()
                                           ("account", "eosio")
                                           ("ram_bytes", ram_bytes_needed)
                                           ("net_weight", -1)
                                           ("cpu_weight", -1)
               );
 
-   stake( N(alice1111111), N(eosio), core_sym::from_string("0.0000"), core_sym::from_string("1.0000") );
+   stake( "alice1111111"_n, "eosio"_n, core_sym::from_string("0.0000"), core_sym::from_string("1.0000") );
 
    REQUIRE_MATCHING_OBJECT( get_total_stake( "eosio" ), mvo()
       ("owner", "eosio")
@@ -5783,7 +5783,7 @@ BOOST_FIXTURE_TEST_CASE( change_limited_account_back_to_unlimited, eosio_system_
    );
 
    BOOST_REQUIRE_EQUAL( wasm_assert_msg( "only supports unlimited accounts" ),
-                        push_action( N(eosio), N(setalimits), mvo()
+                        push_action( "eosio"_n, "setalimits"_n, mvo()
                                           ("account", "eosio")
                                           ("ram_bytes", ram_bytes_needed)
                                           ("net_weight", -1)
@@ -5792,7 +5792,7 @@ BOOST_FIXTURE_TEST_CASE( change_limited_account_back_to_unlimited, eosio_system_
    );
 
    BOOST_REQUIRE_EQUAL( error( "transaction net usage is too high: 128 > 0" ),
-                        push_action( N(eosio), N(setalimits), mvo()
+                        push_action( "eosio"_n, "setalimits"_n, mvo()
                            ("account", "eosio.saving")
                            ("ram_bytes", -1)
                            ("net_weight", -1)
@@ -5801,14 +5801,14 @@ BOOST_FIXTURE_TEST_CASE( change_limited_account_back_to_unlimited, eosio_system_
    );
 
    BOOST_REQUIRE_EQUAL( success(),
-                        push_action( N(eosio), N(setacctnet), mvo()
+                        push_action( "eosio"_n, "setacctnet"_n, mvo()
                            ("account", "eosio")
                            ("net_weight", -1)
                         )
    );
 
    BOOST_REQUIRE_EQUAL( success(),
-                        push_action( N(eosio), N(setacctcpu), mvo()
+                        push_action( "eosio"_n, "setacctcpu"_n, mvo()
                            ("account", "eosio")
                            ("cpu_weight", -1)
 
@@ -5816,7 +5816,7 @@ BOOST_FIXTURE_TEST_CASE( change_limited_account_back_to_unlimited, eosio_system_
    );
 
    BOOST_REQUIRE_EQUAL( success(),
-                        push_action( N(eosio), N(setalimits), mvo()
+                        push_action( "eosio"_n, "setalimits"_n, mvo()
                                           ("account", "eosio.saving")
                                           ("ram_bytes", ram_bytes_needed)
                                           ("net_weight", -1)
@@ -5829,9 +5829,9 @@ BOOST_FIXTURE_TEST_CASE( change_limited_account_back_to_unlimited, eosio_system_
 BOOST_FIXTURE_TEST_CASE( buy_pin_sell_ram, eosio_system_tester ) try {
    BOOST_REQUIRE( get_total_stake( "eosio" ).is_null() );
 
-   transfer( N(eosio), N(alice1111111), core_sym::from_string("1020.0000") );
+   transfer( "eosio"_n, "alice1111111"_n, core_sym::from_string("1020.0000") );
 
-   auto error_msg = stake( N(alice1111111), N(eosio), core_sym::from_string("10.0000"), core_sym::from_string("10.0000") );
+   auto error_msg = stake( "alice1111111"_n, "eosio"_n, core_sym::from_string("10.0000"), core_sym::from_string("10.0000") );
    auto semicolon_pos = error_msg.find(';');
 
    BOOST_REQUIRE_EQUAL( error("account eosio has insufficient ram"),
@@ -5845,11 +5845,11 @@ BOOST_FIXTURE_TEST_CASE( buy_pin_sell_ram, eosio_system_tester ) try {
       ram_bytes_needed += ram_bytes_needed/10; // enough buffer to make up for buyrambytes estimation errors
    }
 
-   auto alice_original_balance = get_balance( N(alice1111111) );
+   auto alice_original_balance = get_balance( "alice1111111"_n );
 
-   BOOST_REQUIRE_EQUAL( success(), buyrambytes( N(alice1111111), N(eosio), static_cast<uint32_t>(ram_bytes_needed) ) );
+   BOOST_REQUIRE_EQUAL( success(), buyrambytes( "alice1111111"_n, "eosio"_n, static_cast<uint32_t>(ram_bytes_needed) ) );
 
-   auto tokens_paid_for_ram = alice_original_balance - get_balance( N(alice1111111) );
+   auto tokens_paid_for_ram = alice_original_balance - get_balance( "alice1111111"_n );
 
    auto total_res = get_total_stake( "eosio" );
 
@@ -5861,7 +5861,7 @@ BOOST_FIXTURE_TEST_CASE( buy_pin_sell_ram, eosio_system_tester ) try {
    );
 
    BOOST_REQUIRE_EQUAL( wasm_assert_msg( "only supports unlimited accounts" ),
-                        push_action( N(eosio), N(setalimits), mvo()
+                        push_action( "eosio"_n, "setalimits"_n, mvo()
                                           ("account", "eosio")
                                           ("ram_bytes", ram_bytes_needed)
                                           ("net_weight", -1)
@@ -5870,17 +5870,17 @@ BOOST_FIXTURE_TEST_CASE( buy_pin_sell_ram, eosio_system_tester ) try {
    );
 
    BOOST_REQUIRE_EQUAL( success(),
-                        push_action( N(eosio), N(setacctram), mvo()
+                        push_action( "eosio"_n, "setacctram"_n, mvo()
                            ("account", "eosio")
                            ("ram_bytes", total_res["ram_bytes"].as_int64() )
                         )
    );
 
-   auto eosio_original_balance = get_balance( N(eosio) );
+   auto eosio_original_balance = get_balance( "eosio"_n );
 
-   BOOST_REQUIRE_EQUAL( success(), sellram( N(eosio), total_res["ram_bytes"].as_int64() ) );
+   BOOST_REQUIRE_EQUAL( success(), sellram( "eosio"_n, total_res["ram_bytes"].as_int64() ) );
 
-   auto tokens_received_by_selling_ram = get_balance( N(eosio) ) - eosio_original_balance;
+   auto tokens_received_by_selling_ram = get_balance( "eosio"_n ) - eosio_original_balance;
 
    BOOST_REQUIRE( double(tokens_paid_for_ram.get_amount() - tokens_received_by_selling_ram.get_amount()) / tokens_paid_for_ram.get_amount() < 0.01 );
 

--- a/tests/eosio.token_tests.cpp
+++ b/tests/eosio.token_tests.cpp
@@ -22,15 +22,15 @@ public:
    eosio_token_tester() {
       produce_blocks( 2 );
 
-      create_accounts( { N(alice), N(bob), N(carol), N(eosio.token) } );
+      create_accounts( { "alice"_n, "bob"_n, "carol"_n, "eosio.token"_n } );
       produce_blocks( 2 );
 
-      set_code( N(eosio.token), contracts::token_wasm() );
-      set_abi( N(eosio.token), contracts::token_abi().data() );
+      set_code( "eosio.token"_n, contracts::token_wasm() );
+      set_abi( "eosio.token"_n, contracts::token_abi().data() );
 
       produce_blocks();
 
-      const auto& accnt = control->db().get<account_object,by_name>( N(eosio.token) );
+      const auto& accnt = control->db().get<account_object,by_name>( "eosio.token"_n );
       abi_def abi;
       BOOST_REQUIRE_EQUAL(abi_serializer::to_abi(accnt.abi, abi), true);
       abi_ser.set_abi(abi, abi_serializer::create_yield_function(abi_serializer_max_time));
@@ -40,7 +40,7 @@ public:
       string action_type_name = abi_ser.get_action_type(name);
 
       action act;
-      act.account = N(eosio.token);
+      act.account = "eosio.token"_n;
       act.name    = name;
       act.data    = abi_ser.variant_to_binary( action_type_name, data, abi_serializer::create_yield_function(abi_serializer_max_time) );
 
@@ -51,7 +51,7 @@ public:
    {
       auto symb = eosio::chain::symbol::from_string(symbolname);
       auto symbol_code = symb.to_symbol_code().value;
-      vector<char> data = get_row_by_account( N(eosio.token), name(symbol_code), N(stat), account_name(symbol_code) );
+      vector<char> data = get_row_by_account( "eosio.token"_n, name(symbol_code), "stat"_n, account_name(symbol_code) );
       return data.empty() ? fc::variant() : abi_ser.binary_to_variant( "currency_stats", data, abi_serializer::create_yield_function(abi_serializer_max_time) );
    }
 
@@ -59,21 +59,21 @@ public:
    {
       auto symb = eosio::chain::symbol::from_string(symbolname);
       auto symbol_code = symb.to_symbol_code().value;
-      vector<char> data = get_row_by_account( N(eosio.token), acc, N(accounts), account_name(symbol_code) );
+      vector<char> data = get_row_by_account( "eosio.token"_n, acc, "accounts"_n, account_name(symbol_code) );
       return data.empty() ? fc::variant() : abi_ser.binary_to_variant( "account", data, abi_serializer::create_yield_function(abi_serializer_max_time) );
    }
 
    action_result create( account_name issuer,
                          asset        maximum_supply ) {
 
-      return push_action( N(eosio.token), N(create), mvo()
+      return push_action( "eosio.token"_n, "create"_n, mvo()
            ( "issuer", issuer)
            ( "maximum_supply", maximum_supply)
       );
    }
 
    action_result issue( account_name issuer, asset quantity, string memo ) {
-      return push_action( issuer, N(issue), mvo()
+      return push_action( issuer, "issue"_n, mvo()
            ( "to", issuer)
            ( "quantity", quantity)
            ( "memo", memo)
@@ -81,7 +81,7 @@ public:
    }
 
    action_result retire( account_name issuer, asset quantity, string memo ) {
-      return push_action( issuer, N(retire), mvo()
+      return push_action( issuer, "retire"_n, mvo()
            ( "quantity", quantity)
            ( "memo", memo)
       );
@@ -92,7 +92,7 @@ public:
                   account_name to,
                   asset        quantity,
                   string       memo ) {
-      return push_action( from, N(transfer), mvo()
+      return push_action( from, "transfer"_n, mvo()
            ( "from", from)
            ( "to", to)
            ( "quantity", quantity)
@@ -103,7 +103,7 @@ public:
    action_result open( account_name owner,
                        const string& symbolname,
                        account_name ram_payer    ) {
-      return push_action( ram_payer, N(open), mvo()
+      return push_action( ram_payer, "open"_n, mvo()
            ( "owner", owner )
            ( "symbol", symbolname )
            ( "ram_payer", ram_payer )
@@ -112,7 +112,7 @@ public:
 
    action_result close( account_name owner,
                         const string& symbolname ) {
-      return push_action( owner, N(close), mvo()
+      return push_action( owner, "close"_n, mvo()
            ( "owner", owner )
            ( "symbol", "0,CERO" )
       );
@@ -125,7 +125,7 @@ BOOST_AUTO_TEST_SUITE(eosio_token_tests)
 
 BOOST_FIXTURE_TEST_CASE( create_tests, eosio_token_tester ) try {
 
-   auto token = create( N(alice), asset::from_string("1000.000 TKN"));
+   auto token = create( "alice"_n, asset::from_string("1000.000 TKN"));
    auto stats = get_stats("3,TKN");
    REQUIRE_MATCHING_OBJECT( stats, mvo()
       ("supply", "0.000 TKN")
@@ -139,14 +139,14 @@ BOOST_FIXTURE_TEST_CASE( create_tests, eosio_token_tester ) try {
 BOOST_FIXTURE_TEST_CASE( create_negative_max_supply, eosio_token_tester ) try {
 
    BOOST_REQUIRE_EQUAL( wasm_assert_msg( "max-supply must be positive" ),
-      create( N(alice), asset::from_string("-1000.000 TKN"))
+      create( "alice"_n, asset::from_string("-1000.000 TKN"))
    );
 
 } FC_LOG_AND_RETHROW()
 
 BOOST_FIXTURE_TEST_CASE( symbol_already_exists, eosio_token_tester ) try {
 
-   auto token = create( N(alice), asset::from_string("100 TKN"));
+   auto token = create( "alice"_n, asset::from_string("100 TKN"));
    auto stats = get_stats("0,TKN");
    REQUIRE_MATCHING_OBJECT( stats, mvo()
       ("supply", "0 TKN")
@@ -156,14 +156,14 @@ BOOST_FIXTURE_TEST_CASE( symbol_already_exists, eosio_token_tester ) try {
    produce_blocks(1);
 
    BOOST_REQUIRE_EQUAL( wasm_assert_msg( "token with symbol already exists" ),
-                        create( N(alice), asset::from_string("100 TKN"))
+                        create( "alice"_n, asset::from_string("100 TKN"))
    );
 
 } FC_LOG_AND_RETHROW()
 
 BOOST_FIXTURE_TEST_CASE( create_max_supply, eosio_token_tester ) try {
 
-   auto token = create( N(alice), asset::from_string("4611686018427387903 TKN"));
+   auto token = create( "alice"_n, asset::from_string("4611686018427387903 TKN"));
    auto stats = get_stats("0,TKN");
    REQUIRE_MATCHING_OBJECT( stats, mvo()
       ("supply", "0 TKN")
@@ -178,7 +178,7 @@ BOOST_FIXTURE_TEST_CASE( create_max_supply, eosio_token_tester ) try {
    static_assert(std::is_trivially_copyable<asset>::value, "asset is not trivially copyable");
    memcpy(&max, &amount, sizeof(share_type)); // hack in an invalid amount
 
-   BOOST_CHECK_EXCEPTION( create( N(alice), max) , asset_type_exception, [](const asset_type_exception& e) {
+   BOOST_CHECK_EXCEPTION( create( "alice"_n, max) , asset_type_exception, [](const asset_type_exception& e) {
       return expect_assert_message(e, "magnitude of asset amount must be less than 2^62");
    });
 
@@ -187,7 +187,7 @@ BOOST_FIXTURE_TEST_CASE( create_max_supply, eosio_token_tester ) try {
 
 BOOST_FIXTURE_TEST_CASE( create_max_decimals, eosio_token_tester ) try {
 
-   auto token = create( N(alice), asset::from_string("1.000000000000000000 TKN"));
+   auto token = create( "alice"_n, asset::from_string("1.000000000000000000 TKN"));
    auto stats = get_stats("18,TKN");
    REQUIRE_MATCHING_OBJECT( stats, mvo()
       ("supply", "0.000000000000000000 TKN")
@@ -203,7 +203,7 @@ BOOST_FIXTURE_TEST_CASE( create_max_decimals, eosio_token_tester ) try {
    static_assert(std::is_trivially_copyable<asset>::value, "asset is not trivially copyable");
    memcpy(&max, &amount, sizeof(share_type)); // hack in an invalid amount
 
-   BOOST_CHECK_EXCEPTION( create( N(alice), max) , asset_type_exception, [](const asset_type_exception& e) {
+   BOOST_CHECK_EXCEPTION( create( "alice"_n, max) , asset_type_exception, [](const asset_type_exception& e) {
       return expect_assert_message(e, "magnitude of asset amount must be less than 2^62");
    });
 
@@ -211,10 +211,10 @@ BOOST_FIXTURE_TEST_CASE( create_max_decimals, eosio_token_tester ) try {
 
 BOOST_FIXTURE_TEST_CASE( issue_tests, eosio_token_tester ) try {
 
-   auto token = create( N(alice), asset::from_string("1000.000 TKN"));
+   auto token = create( "alice"_n, asset::from_string("1000.000 TKN"));
    produce_blocks(1);
 
-   issue( N(alice), asset::from_string("500.000 TKN"), "hola" );
+   issue( "alice"_n, asset::from_string("500.000 TKN"), "hola" );
 
    auto stats = get_stats("3,TKN");
    REQUIRE_MATCHING_OBJECT( stats, mvo()
@@ -223,21 +223,21 @@ BOOST_FIXTURE_TEST_CASE( issue_tests, eosio_token_tester ) try {
       ("issuer", "alice")
    );
 
-   auto alice_balance = get_account(N(alice), "3,TKN");
+   auto alice_balance = get_account("alice"_n, "3,TKN");
    REQUIRE_MATCHING_OBJECT( alice_balance, mvo()
       ("balance", "500.000 TKN")
    );
 
    BOOST_REQUIRE_EQUAL( wasm_assert_msg( "quantity exceeds available supply" ),
-                        issue( N(alice), asset::from_string("500.001 TKN"), "hola" )
+                        issue( "alice"_n, asset::from_string("500.001 TKN"), "hola" )
    );
 
    BOOST_REQUIRE_EQUAL( wasm_assert_msg( "must issue positive quantity" ),
-                        issue( N(alice), asset::from_string("-1.000 TKN"), "hola" )
+                        issue( "alice"_n, asset::from_string("-1.000 TKN"), "hola" )
    );
 
    BOOST_REQUIRE_EQUAL( success(),
-                        issue( N(alice), asset::from_string("1.000 TKN"), "hola" )
+                        issue( "alice"_n, asset::from_string("1.000 TKN"), "hola" )
    );
 
 
@@ -245,10 +245,10 @@ BOOST_FIXTURE_TEST_CASE( issue_tests, eosio_token_tester ) try {
 
 BOOST_FIXTURE_TEST_CASE( retire_tests, eosio_token_tester ) try {
 
-   auto token = create( N(alice), asset::from_string("1000.000 TKN"));
+   auto token = create( "alice"_n, asset::from_string("1000.000 TKN"));
    produce_blocks(1);
 
-   BOOST_REQUIRE_EQUAL( success(), issue( N(alice), asset::from_string("500.000 TKN"), "hola" ) );
+   BOOST_REQUIRE_EQUAL( success(), issue( "alice"_n, asset::from_string("500.000 TKN"), "hola" ) );
 
    auto stats = get_stats("3,TKN");
    REQUIRE_MATCHING_OBJECT( stats, mvo()
@@ -257,55 +257,55 @@ BOOST_FIXTURE_TEST_CASE( retire_tests, eosio_token_tester ) try {
       ("issuer", "alice")
    );
 
-   auto alice_balance = get_account(N(alice), "3,TKN");
+   auto alice_balance = get_account("alice"_n, "3,TKN");
    REQUIRE_MATCHING_OBJECT( alice_balance, mvo()
       ("balance", "500.000 TKN")
    );
 
-   BOOST_REQUIRE_EQUAL( success(), retire( N(alice), asset::from_string("200.000 TKN"), "hola" ) );
+   BOOST_REQUIRE_EQUAL( success(), retire( "alice"_n, asset::from_string("200.000 TKN"), "hola" ) );
    stats = get_stats("3,TKN");
    REQUIRE_MATCHING_OBJECT( stats, mvo()
       ("supply", "300.000 TKN")
       ("max_supply", "1000.000 TKN")
       ("issuer", "alice")
    );
-   alice_balance = get_account(N(alice), "3,TKN");
+   alice_balance = get_account("alice"_n, "3,TKN");
    REQUIRE_MATCHING_OBJECT( alice_balance, mvo()
       ("balance", "300.000 TKN")
    );
 
    //should fail to retire more than current supply
-   BOOST_REQUIRE_EQUAL( wasm_assert_msg("overdrawn balance"), retire( N(alice), asset::from_string("500.000 TKN"), "hola" ) );
+   BOOST_REQUIRE_EQUAL( wasm_assert_msg("overdrawn balance"), retire( "alice"_n, asset::from_string("500.000 TKN"), "hola" ) );
 
-   BOOST_REQUIRE_EQUAL( success(), transfer( N(alice), N(bob), asset::from_string("200.000 TKN"), "hola" ) );
+   BOOST_REQUIRE_EQUAL( success(), transfer( "alice"_n, "bob"_n, asset::from_string("200.000 TKN"), "hola" ) );
    //should fail to retire since tokens are not on the issuer's balance
-   BOOST_REQUIRE_EQUAL( wasm_assert_msg("overdrawn balance"), retire( N(alice), asset::from_string("300.000 TKN"), "hola" ) );
+   BOOST_REQUIRE_EQUAL( wasm_assert_msg("overdrawn balance"), retire( "alice"_n, asset::from_string("300.000 TKN"), "hola" ) );
    //transfer tokens back
-   BOOST_REQUIRE_EQUAL( success(), transfer( N(bob), N(alice), asset::from_string("200.000 TKN"), "hola" ) );
+   BOOST_REQUIRE_EQUAL( success(), transfer( "bob"_n, "alice"_n, asset::from_string("200.000 TKN"), "hola" ) );
 
-   BOOST_REQUIRE_EQUAL( success(), retire( N(alice), asset::from_string("300.000 TKN"), "hola" ) );
+   BOOST_REQUIRE_EQUAL( success(), retire( "alice"_n, asset::from_string("300.000 TKN"), "hola" ) );
    stats = get_stats("3,TKN");
    REQUIRE_MATCHING_OBJECT( stats, mvo()
       ("supply", "0.000 TKN")
       ("max_supply", "1000.000 TKN")
       ("issuer", "alice")
    );
-   alice_balance = get_account(N(alice), "3,TKN");
+   alice_balance = get_account("alice"_n, "3,TKN");
    REQUIRE_MATCHING_OBJECT( alice_balance, mvo()
       ("balance", "0.000 TKN")
    );
 
    //trying to retire tokens with zero supply
-   BOOST_REQUIRE_EQUAL( wasm_assert_msg("overdrawn balance"), retire( N(alice), asset::from_string("1.000 TKN"), "hola" ) );
+   BOOST_REQUIRE_EQUAL( wasm_assert_msg("overdrawn balance"), retire( "alice"_n, asset::from_string("1.000 TKN"), "hola" ) );
 
 } FC_LOG_AND_RETHROW()
 
 BOOST_FIXTURE_TEST_CASE( transfer_tests, eosio_token_tester ) try {
 
-   auto token = create( N(alice), asset::from_string("1000 CERO"));
+   auto token = create( "alice"_n, asset::from_string("1000 CERO"));
    produce_blocks(1);
 
-   issue( N(alice), asset::from_string("1000 CERO"), "hola" );
+   issue( "alice"_n, asset::from_string("1000 CERO"), "hola" );
 
    auto stats = get_stats("0,CERO");
    REQUIRE_MATCHING_OBJECT( stats, mvo()
@@ -314,21 +314,21 @@ BOOST_FIXTURE_TEST_CASE( transfer_tests, eosio_token_tester ) try {
       ("issuer", "alice")
    );
 
-   auto alice_balance = get_account(N(alice), "0,CERO");
+   auto alice_balance = get_account("alice"_n, "0,CERO");
    REQUIRE_MATCHING_OBJECT( alice_balance, mvo()
       ("balance", "1000 CERO")
    );
 
-   transfer( N(alice), N(bob), asset::from_string("300 CERO"), "hola" );
+   transfer( "alice"_n, "bob"_n, asset::from_string("300 CERO"), "hola" );
 
-   alice_balance = get_account(N(alice), "0,CERO");
+   alice_balance = get_account("alice"_n, "0,CERO");
    REQUIRE_MATCHING_OBJECT( alice_balance, mvo()
       ("balance", "700 CERO")
       ("frozen", 0)
       ("whitelist", 1)
    );
 
-   auto bob_balance = get_account(N(bob), "0,CERO");
+   auto bob_balance = get_account("bob"_n, "0,CERO");
    REQUIRE_MATCHING_OBJECT( bob_balance, mvo()
       ("balance", "300 CERO")
       ("frozen", 0)
@@ -336,11 +336,11 @@ BOOST_FIXTURE_TEST_CASE( transfer_tests, eosio_token_tester ) try {
    );
 
    BOOST_REQUIRE_EQUAL( wasm_assert_msg( "overdrawn balance" ),
-      transfer( N(alice), N(bob), asset::from_string("701 CERO"), "hola" )
+      transfer( "alice"_n, "bob"_n, asset::from_string("701 CERO"), "hola" )
    );
 
    BOOST_REQUIRE_EQUAL( wasm_assert_msg( "must transfer positive quantity" ),
-      transfer( N(alice), N(bob), asset::from_string("-1000 CERO"), "hola" )
+      transfer( "alice"_n, "bob"_n, asset::from_string("-1000 CERO"), "hola" )
    );
 
 
@@ -348,73 +348,73 @@ BOOST_FIXTURE_TEST_CASE( transfer_tests, eosio_token_tester ) try {
 
 BOOST_FIXTURE_TEST_CASE( open_tests, eosio_token_tester ) try {
 
-   auto token = create( N(alice), asset::from_string("1000 CERO"));
+   auto token = create( "alice"_n, asset::from_string("1000 CERO"));
 
-   auto alice_balance = get_account(N(alice), "0,CERO");
+   auto alice_balance = get_account("alice"_n, "0,CERO");
    BOOST_REQUIRE_EQUAL(true, alice_balance.is_null() );
    BOOST_REQUIRE_EQUAL( wasm_assert_msg("tokens can only be issued to issuer account"),
-                        push_action( N(alice), N(issue), mvo()
+                        push_action( "alice"_n, "issue"_n, mvo()
                                      ( "to",       "bob")
                                      ( "quantity", asset::from_string("1000 CERO") )
                                      ( "memo",     "") ) );
-   BOOST_REQUIRE_EQUAL( success(), issue( N(alice), asset::from_string("1000 CERO"), "issue" ) );
+   BOOST_REQUIRE_EQUAL( success(), issue( "alice"_n, asset::from_string("1000 CERO"), "issue" ) );
 
-   alice_balance = get_account(N(alice), "0,CERO");
+   alice_balance = get_account("alice"_n, "0,CERO");
    REQUIRE_MATCHING_OBJECT( alice_balance, mvo()
       ("balance", "1000 CERO")
    );
 
-   auto bob_balance = get_account(N(bob), "0,CERO");
+   auto bob_balance = get_account("bob"_n, "0,CERO");
    BOOST_REQUIRE_EQUAL(true, bob_balance.is_null() );
 
    BOOST_REQUIRE_EQUAL( wasm_assert_msg("owner account does not exist"),
-                        open( N(nonexistent), "0,CERO", N(alice) ) );
+                        open( "nonexistent"_n, "0,CERO", "alice"_n ) );
    BOOST_REQUIRE_EQUAL( success(),
-                        open( N(bob),         "0,CERO", N(alice) ) );
+                        open( "bob"_n,         "0,CERO", "alice"_n ) );
 
-   bob_balance = get_account(N(bob), "0,CERO");
+   bob_balance = get_account("bob"_n, "0,CERO");
    REQUIRE_MATCHING_OBJECT( bob_balance, mvo()
       ("balance", "0 CERO")
    );
 
-   BOOST_REQUIRE_EQUAL( success(), transfer( N(alice), N(bob), asset::from_string("200 CERO"), "hola" ) );
+   BOOST_REQUIRE_EQUAL( success(), transfer( "alice"_n, "bob"_n, asset::from_string("200 CERO"), "hola" ) );
 
-   bob_balance = get_account(N(bob), "0,CERO");
+   bob_balance = get_account("bob"_n, "0,CERO");
    REQUIRE_MATCHING_OBJECT( bob_balance, mvo()
       ("balance", "200 CERO")
    );
 
    BOOST_REQUIRE_EQUAL( wasm_assert_msg( "symbol does not exist" ),
-                        open( N(carol), "0,INVALID", N(alice) ) );
+                        open( "carol"_n, "0,INVALID", "alice"_n ) );
 
    BOOST_REQUIRE_EQUAL( wasm_assert_msg( "symbol precision mismatch" ),
-                        open( N(carol), "1,CERO", N(alice) ) );
+                        open( "carol"_n, "1,CERO", "alice"_n ) );
 
 } FC_LOG_AND_RETHROW()
 
 BOOST_FIXTURE_TEST_CASE( close_tests, eosio_token_tester ) try {
 
-   auto token = create( N(alice), asset::from_string("1000 CERO"));
+   auto token = create( "alice"_n, asset::from_string("1000 CERO"));
 
-   auto alice_balance = get_account(N(alice), "0,CERO");
+   auto alice_balance = get_account("alice"_n, "0,CERO");
    BOOST_REQUIRE_EQUAL(true, alice_balance.is_null() );
 
-   BOOST_REQUIRE_EQUAL( success(), issue( N(alice), asset::from_string("1000 CERO"), "hola" ) );
+   BOOST_REQUIRE_EQUAL( success(), issue( "alice"_n, asset::from_string("1000 CERO"), "hola" ) );
 
-   alice_balance = get_account(N(alice), "0,CERO");
+   alice_balance = get_account("alice"_n, "0,CERO");
    REQUIRE_MATCHING_OBJECT( alice_balance, mvo()
       ("balance", "1000 CERO")
    );
 
-   BOOST_REQUIRE_EQUAL( success(), transfer( N(alice), N(bob), asset::from_string("1000 CERO"), "hola" ) );
+   BOOST_REQUIRE_EQUAL( success(), transfer( "alice"_n, "bob"_n, asset::from_string("1000 CERO"), "hola" ) );
 
-   alice_balance = get_account(N(alice), "0,CERO");
+   alice_balance = get_account("alice"_n, "0,CERO");
    REQUIRE_MATCHING_OBJECT( alice_balance, mvo()
       ("balance", "0 CERO")
    );
 
-   BOOST_REQUIRE_EQUAL( success(), close( N(alice), "0,CERO" ) );
-   alice_balance = get_account(N(alice), "0,CERO");
+   BOOST_REQUIRE_EQUAL( success(), close( "alice"_n, "0,CERO" ) );
+   alice_balance = get_account("alice"_n, "0,CERO");
    BOOST_REQUIRE_EQUAL(true, alice_balance.is_null() );
 
 } FC_LOG_AND_RETHROW()

--- a/tests/eosio.wrap_tests.cpp
+++ b/tests/eosio.wrap_tests.cpp
@@ -20,18 +20,18 @@ class eosio_wrap_tester : public tester {
 public:
 
    eosio_wrap_tester() {
-      create_accounts( { N(eosio.msig), N(prod1), N(prod2), N(prod3), N(prod4), N(prod5), N(alice), N(bob), N(carol) } );
+      create_accounts( { "eosio.msig"_n, "prod1"_n, "prod2"_n, "prod3"_n, "prod4"_n, "prod5"_n, "alice"_n, "bob"_n, "carol"_n } );
       produce_block();
 
 
-      base_tester::push_action(config::system_account_name, N(setpriv),
+      base_tester::push_action(config::system_account_name, "setpriv"_n,
                                  config::system_account_name,  mutable_variant_object()
                                  ("account", "eosio.msig")
                                  ("is_priv", 1)
       );
 
-      set_code( N(eosio.msig), contracts::msig_wasm() );
-      set_abi( N(eosio.msig), contracts::msig_abi().data() );
+      set_code( "eosio.msig"_n, contracts::msig_wasm() );
+      set_abi( "eosio.msig"_n, contracts::msig_abi().data() );
 
       produce_blocks();
 
@@ -41,7 +41,7 @@ public:
       trx.actions.emplace_back( vector<permission_level>{{config::system_account_name, config::active_name}},
                                 newaccount{
                                    .creator  = config::system_account_name,
-                                   .name     = N(eosio.wrap),
+                                   .name     = "eosio.wrap"_n,
                                    .owner    = auth,
                                    .active   = auth,
                                 });
@@ -50,15 +50,15 @@ public:
       trx.sign( get_private_key( config::system_account_name, "active" ), control->get_chain_id()  );
       push_transaction( trx );
 
-      base_tester::push_action(config::system_account_name, N(setpriv),
+      base_tester::push_action(config::system_account_name, "setpriv"_n,
                                  config::system_account_name,  mutable_variant_object()
                                  ("account", "eosio.wrap")
                                  ("is_priv", 1)
       );
 
       auto system_private_key = get_private_key( config::system_account_name, "active" );
-      set_code( N(eosio.wrap), contracts::wrap_wasm(), &system_private_key );
-      set_abi( N(eosio.wrap), contracts::wrap_abi().data(), &system_private_key );
+      set_code( "eosio.wrap"_n, contracts::wrap_wasm(), &system_private_key );
+      set_abi( "eosio.wrap"_n, contracts::wrap_abi().data(), &system_private_key );
 
       produce_blocks();
 
@@ -70,11 +70,11 @@ public:
                      { get_private_key( config::system_account_name, "active" ) }
                    );
 
-      set_producers( {N(prod1), N(prod2), N(prod3), N(prod4), N(prod5)} );
+      set_producers( {"prod1"_n, "prod2"_n, "prod3"_n, "prod4"_n, "prod5"_n} );
 
       produce_blocks();
 
-      const auto& accnt = control->db().get<account_object,by_name>( N(eosio.wrap) );
+      const auto& accnt = control->db().get<account_object,by_name>( "eosio.wrap"_n );
       abi_def abi;
       BOOST_REQUIRE_EQUAL(abi_serializer::to_abi(accnt.abi, abi), true);
       abi_ser.set_abi(abi, abi_serializer::create_yield_function(abi_serializer_max_time));
@@ -85,7 +85,7 @@ public:
    }
 
    void propose( name proposer, name proposal_name, vector<permission_level> requested_permissions, const transaction& trx ) {
-      push_action( N(eosio.msig), N(propose), proposer, mvo()
+      push_action( "eosio.msig"_n, "propose"_n, proposer, mvo()
                      ("proposer",      proposer)
                      ("proposal_name", proposal_name)
                      ("requested",     requested_permissions)
@@ -94,7 +94,7 @@ public:
    }
 
    void approve( name proposer, name proposal_name, name approver ) {
-      push_action( N(eosio.msig), N(approve), approver, mvo()
+      push_action( "eosio.msig"_n, "approve"_n, approver, mvo()
                      ("proposer",      proposer)
                      ("proposal_name", proposal_name)
                      ("level",         permission_level{approver, config::active_name} )
@@ -102,7 +102,7 @@ public:
    }
 
    void unapprove( name proposer, name proposal_name, name unapprover ) {
-      push_action( N(eosio.msig), N(unapprove), unapprover, mvo()
+      push_action( "eosio.msig"_n, "unapprove"_n, unapprover, mvo()
                      ("proposer",      proposer)
                      ("proposal_name", proposal_name)
                      ("level",         permission_level{unapprover, config::active_name})
@@ -163,7 +163,7 @@ transaction eosio_wrap_tester::reqauth( account_name from, const vector<permissi
 BOOST_AUTO_TEST_SUITE(eosio_wrap_tests)
 
 BOOST_FIXTURE_TEST_CASE( wrap_exec_direct, eosio_wrap_tester ) try {
-   auto trx = reqauth( N(bob), {permission_level{N(bob), config::active_name}} );
+   auto trx = reqauth( "bob"_n, {permission_level{"bob"_n, config::active_name}} );
 
    transaction_trace_ptr trace;
    control->applied_transaction.connect(
@@ -173,18 +173,18 @@ BOOST_FIXTURE_TEST_CASE( wrap_exec_direct, eosio_wrap_tester ) try {
    } );
 
    {
-      signed_transaction wrap_trx( wrap_exec( N(alice), trx ), {}, {} );
+      signed_transaction wrap_trx( wrap_exec( "alice"_n, trx ), {}, {} );
       /*
       set_transaction_headers( wrap_trx );
-      wrap_trx.actions.emplace_back( get_action( N(eosio.wrap), N(exec),
-                                                 {{N(alice), config::active_name}, {N(eosio.wrap), config::active_name}},
+      wrap_trx.actions.emplace_back( get_action( "eosio.wrap"_n, "exec"_n,
+                                                 {{"alice"_n, config::active_name}, {"eosio.wrap"_n, config::active_name}},
                                                  mvo()
                                                    ("executer", "alice")
                                                    ("trx", trx)
       ) );
       */
-      wrap_trx.sign( get_private_key( N(alice), "active" ), control->get_chain_id() );
-      for( const auto& actor : {N(prod1), N(prod2), N(prod3), N(prod4)} ) {
+      wrap_trx.sign( get_private_key( "alice"_n, "active" ), control->get_chain_id() );
+      for( const auto& actor : {"prod1"_n, "prod2"_n, "prod3"_n, "prod4"_n} ) {
          wrap_trx.sign( get_private_key( actor, "active" ), control->get_chain_id() );
       }
       push_transaction( wrap_trx );
@@ -195,27 +195,27 @@ BOOST_FIXTURE_TEST_CASE( wrap_exec_direct, eosio_wrap_tester ) try {
    BOOST_REQUIRE( bool(trace) );
    BOOST_REQUIRE_EQUAL( 1, trace->action_traces.size() );
    BOOST_REQUIRE_EQUAL( config::system_account_name, name{trace->action_traces[0].act.account} );
-   BOOST_REQUIRE_EQUAL( N(reqauth), name{trace->action_traces[0].act.name} );
+   BOOST_REQUIRE_EQUAL( "reqauth"_n, name{trace->action_traces[0].act.name} );
    BOOST_REQUIRE_EQUAL( transaction_receipt::executed, trace->receipt->status );
 
 } FC_LOG_AND_RETHROW()
 
 BOOST_FIXTURE_TEST_CASE( wrap_with_msig, eosio_wrap_tester ) try {
-   auto trx = reqauth( N(bob), {permission_level{N(bob), config::active_name}} );
-   auto wrap_trx = wrap_exec( N(alice), trx );
+   auto trx = reqauth( "bob"_n, {permission_level{"bob"_n, config::active_name}} );
+   auto wrap_trx = wrap_exec( "alice"_n, trx );
 
-   propose( N(carol), N(first),
-            { {N(alice), N(active)},
-              {N(prod1), N(active)}, {N(prod2), N(active)}, {N(prod3), N(active)}, {N(prod4), N(active)}, {N(prod5), N(active)} },
+   propose( "carol"_n, "first"_n,
+            { {"alice"_n, "active"_n},
+              {"prod1"_n, "active"_n}, {"prod2"_n, "active"_n}, {"prod3"_n, "active"_n}, {"prod4"_n, "active"_n}, {"prod5"_n, "active"_n} },
             wrap_trx );
 
-   approve( N(carol), N(first), N(alice) ); // alice must approve since she is the executer of the wrap::exec action
+   approve( "carol"_n, "first"_n, "alice"_n ); // alice must approve since she is the executer of the wrap::exec action
 
    // More than 2/3 of block producers approve
-   approve( N(carol), N(first), N(prod1) );
-   approve( N(carol), N(first), N(prod2) );
-   approve( N(carol), N(first), N(prod3) );
-   approve( N(carol), N(first), N(prod4) );
+   approve( "carol"_n, "first"_n, "prod1"_n );
+   approve( "carol"_n, "first"_n, "prod2"_n );
+   approve( "carol"_n, "first"_n, "prod3"_n );
+   approve( "carol"_n, "first"_n, "prod4"_n );
 
    vector<transaction_trace_ptr> traces;
    control->applied_transaction.connect(
@@ -227,7 +227,7 @@ BOOST_FIXTURE_TEST_CASE( wrap_with_msig, eosio_wrap_tester ) try {
    } );
 
    // Now the proposal should be ready to execute
-   push_action( N(eosio.msig), N(exec), N(alice), mvo()
+   push_action( "eosio.msig"_n, "exec"_n, "alice"_n, mvo()
                   ("proposer",      "carol")
                   ("proposal_name", "first")
                   ("executer",      "alice")
@@ -238,43 +238,43 @@ BOOST_FIXTURE_TEST_CASE( wrap_with_msig, eosio_wrap_tester ) try {
    BOOST_REQUIRE_EQUAL( 2, traces.size() );
 
    BOOST_REQUIRE_EQUAL( 1, traces[0]->action_traces.size() );
-   BOOST_REQUIRE_EQUAL( N(eosio.wrap), name{traces[0]->action_traces[0].act.account} );
-   BOOST_REQUIRE_EQUAL( N(exec), name{traces[0]->action_traces[0].act.name} );
+   BOOST_REQUIRE_EQUAL( "eosio.wrap"_n, name{traces[0]->action_traces[0].act.account} );
+   BOOST_REQUIRE_EQUAL( "exec"_n, name{traces[0]->action_traces[0].act.name} );
    BOOST_REQUIRE_EQUAL( transaction_receipt::executed, traces[0]->receipt->status );
 
    BOOST_REQUIRE_EQUAL( 1, traces[1]->action_traces.size() );
    BOOST_REQUIRE_EQUAL( config::system_account_name, name{traces[1]->action_traces[0].act.account} );
-   BOOST_REQUIRE_EQUAL( N(reqauth), name{traces[1]->action_traces[0].act.name} );
+   BOOST_REQUIRE_EQUAL( "reqauth"_n, name{traces[1]->action_traces[0].act.name} );
    BOOST_REQUIRE_EQUAL( transaction_receipt::executed, traces[1]->receipt->status );
 
 } FC_LOG_AND_RETHROW()
 
 BOOST_FIXTURE_TEST_CASE( wrap_with_msig_unapprove, eosio_wrap_tester ) try {
-   auto trx = reqauth( N(bob), {permission_level{N(bob), config::active_name}} );
-   auto wrap_trx = wrap_exec( N(alice), trx );
+   auto trx = reqauth( "bob"_n, {permission_level{"bob"_n, config::active_name}} );
+   auto wrap_trx = wrap_exec( "alice"_n, trx );
 
-   propose( N(carol), N(first),
-            { {N(alice), N(active)},
-              {N(prod1), N(active)}, {N(prod2), N(active)}, {N(prod3), N(active)}, {N(prod4), N(active)}, {N(prod5), N(active)} },
+   propose( "carol"_n, "first"_n,
+            { {"alice"_n, "active"_n},
+              {"prod1"_n, "active"_n}, {"prod2"_n, "active"_n}, {"prod3"_n, "active"_n}, {"prod4"_n, "active"_n}, {"prod5"_n, "active"_n} },
             wrap_trx );
 
-   approve( N(carol), N(first), N(alice) ); // alice must approve since she is the executer of the wrap::exec action
+   approve( "carol"_n, "first"_n, "alice"_n ); // alice must approve since she is the executer of the wrap::exec action
 
    // 3 of the 4 needed producers approve
-   approve( N(carol), N(first), N(prod1) );
-   approve( N(carol), N(first), N(prod2) );
-   approve( N(carol), N(first), N(prod3) );
+   approve( "carol"_n, "first"_n, "prod1"_n );
+   approve( "carol"_n, "first"_n, "prod2"_n );
+   approve( "carol"_n, "first"_n, "prod3"_n );
 
    // first producer takes back approval
-   unapprove( N(carol), N(first), N(prod1) );
+   unapprove( "carol"_n, "first"_n, "prod1"_n );
 
    // fourth producer approves but the total number of approving producers is still 3 which is less than two-thirds of producers
-   approve( N(carol), N(first), N(prod4) );
+   approve( "carol"_n, "first"_n, "prod4"_n );
 
    produce_block();
 
    // The proposal should not have sufficient approvals to pass the authorization checks of eosio.wrap::exec.
-   BOOST_REQUIRE_EXCEPTION( push_action( N(eosio.msig), N(exec), N(alice), mvo()
+   BOOST_REQUIRE_EXCEPTION( push_action( "eosio.msig"_n, "exec"_n, "alice"_n, mvo()
                                           ("proposer",      "carol")
                                           ("proposal_name", "first")
                                           ("executer",      "alice")
@@ -285,38 +285,38 @@ BOOST_FIXTURE_TEST_CASE( wrap_with_msig_unapprove, eosio_wrap_tester ) try {
 } FC_LOG_AND_RETHROW()
 
 BOOST_FIXTURE_TEST_CASE( wrap_with_msig_producers_change, eosio_wrap_tester ) try {
-   create_accounts( { N(newprod1) } );
+   create_accounts( { "newprod1"_n } );
 
-   auto trx = reqauth( N(bob), {permission_level{N(bob), config::active_name}} );
-   auto wrap_trx = wrap_exec( N(alice), trx, 36000 );
+   auto trx = reqauth( "bob"_n, {permission_level{"bob"_n, config::active_name}} );
+   auto wrap_trx = wrap_exec( "alice"_n, trx, 36000 );
 
-   propose( N(carol), N(first),
-            { {N(alice), N(active)},
-              {N(prod1), N(active)}, {N(prod2), N(active)}, {N(prod3), N(active)}, {N(prod4), N(active)}, {N(prod5), N(active)} },
+   propose( "carol"_n, "first"_n,
+            { {"alice"_n, "active"_n},
+              {"prod1"_n, "active"_n}, {"prod2"_n, "active"_n}, {"prod3"_n, "active"_n}, {"prod4"_n, "active"_n}, {"prod5"_n, "active"_n} },
             wrap_trx );
 
-   approve( N(carol), N(first), N(alice) ); // alice must approve since she is the executer of the wrap::exec action
+   approve( "carol"_n, "first"_n, "alice"_n ); // alice must approve since she is the executer of the wrap::exec action
 
    // 2 of the 4 needed producers approve
-   approve( N(carol), N(first), N(prod1) );
-   approve( N(carol), N(first), N(prod2) );
+   approve( "carol"_n, "first"_n, "prod1"_n );
+   approve( "carol"_n, "first"_n, "prod2"_n );
 
    produce_block();
 
-   set_producers( {N(prod1), N(prod2), N(prod3), N(prod4), N(prod5), N(newprod1)} ); // With 6 producers, the 2/3+1 threshold becomes 5
+   set_producers( {"prod1"_n, "prod2"_n, "prod3"_n, "prod4"_n, "prod5"_n, "newprod1"_n} ); // With 6 producers, the 2/3+1 threshold becomes 5
 
    while( control->active_producers().producers.size() != 6 ) {
       produce_block();
    }
 
    // Now two more block producers approve which would have been sufficient under the old schedule but not the new one.
-   approve( N(carol), N(first), N(prod3) );
-   approve( N(carol), N(first), N(prod4) );
+   approve( "carol"_n, "first"_n, "prod3"_n );
+   approve( "carol"_n, "first"_n, "prod4"_n );
 
    produce_block();
 
    // The proposal has four of the five requested approvals but they are not sufficient to satisfy the authorization checks of eosio.wrap::exec.
-   BOOST_REQUIRE_EXCEPTION( push_action( N(eosio.msig), N(exec), N(alice), mvo()
+   BOOST_REQUIRE_EXCEPTION( push_action( "eosio.msig"_n, "exec"_n, "alice"_n, mvo()
                                           ("proposer",      "carol")
                                           ("proposal_name", "first")
                                           ("executer",      "alice")
@@ -325,13 +325,13 @@ BOOST_FIXTURE_TEST_CASE( wrap_with_msig_producers_change, eosio_wrap_tester ) tr
    );
 
    // Unfortunately the new producer cannot approve because they were not in the original requested approvals.
-   BOOST_REQUIRE_EXCEPTION( approve( N(carol), N(first), N(newprod1) ),
+   BOOST_REQUIRE_EXCEPTION( approve( "carol"_n, "first"_n, "newprod1"_n ),
                             eosio_assert_message_exception,
                             eosio_assert_message_is("approval is not on the list of requested approvals")
    );
 
    // But prod5 still can provide the fifth approval necessary to satisfy the 2/3+1 threshold of the new producer set
-   approve( N(carol), N(first), N(prod5) );
+   approve( "carol"_n, "first"_n, "prod5"_n );
 
    vector<transaction_trace_ptr> traces;
    control->applied_transaction.connect(
@@ -343,7 +343,7 @@ BOOST_FIXTURE_TEST_CASE( wrap_with_msig_producers_change, eosio_wrap_tester ) tr
    } );
 
    // Now the proposal should be ready to execute
-   push_action( N(eosio.msig), N(exec), N(alice), mvo()
+   push_action( "eosio.msig"_n, "exec"_n, "alice"_n, mvo()
                   ("proposer",      "carol")
                   ("proposal_name", "first")
                   ("executer",      "alice")
@@ -354,13 +354,13 @@ BOOST_FIXTURE_TEST_CASE( wrap_with_msig_producers_change, eosio_wrap_tester ) tr
    BOOST_REQUIRE_EQUAL( 2, traces.size() );
 
    BOOST_REQUIRE_EQUAL( 1, traces[0]->action_traces.size() );
-   BOOST_REQUIRE_EQUAL( N(eosio.wrap), name{traces[0]->action_traces[0].act.account} );
-   BOOST_REQUIRE_EQUAL( N(exec), name{traces[0]->action_traces[0].act.name} );
+   BOOST_REQUIRE_EQUAL( "eosio.wrap"_n, name{traces[0]->action_traces[0].act.account} );
+   BOOST_REQUIRE_EQUAL( "exec"_n, name{traces[0]->action_traces[0].act.name} );
    BOOST_REQUIRE_EQUAL( transaction_receipt::executed, traces[0]->receipt->status );
 
    BOOST_REQUIRE_EQUAL( 1, traces[1]->action_traces.size() );
    BOOST_REQUIRE_EQUAL( config::system_account_name, name{traces[1]->action_traces[0].act.account} );
-   BOOST_REQUIRE_EQUAL( N(reqauth), name{traces[1]->action_traces[0].act.name} );
+   BOOST_REQUIRE_EQUAL( "reqauth"_n, name{traces[1]->action_traces[0].act.name} );
    BOOST_REQUIRE_EQUAL( transaction_receipt::executed, traces[1]->receipt->status );
 
 } FC_LOG_AND_RETHROW()


### PR DESCRIPTION
The tests now build and pass with the latest Mandel (tested manually). However, the latest container produced by Mandel's cicd triggers a cicd-only issue in this repo, so this PR doesn't update to it. `eosio-ld` on the newest container, when used by this cicd, times out at 6 hours. The same procedure run locally using the newest container succeeds. `nproc` on the cicd system is `2`.