### PR TITLE
Remove duplicated check

### DIFF
--- a/contracts/eosio.token/src/eosio.token.cpp
+++ b/contracts/eosio.token/src/eosio.token.cpp
@@ -8,7 +8,6 @@ void token::create( const name&   issuer,
     require_auth( get_self() );
 
     auto sym = maximum_supply.symbol;
-    check( sym.is_valid(), "invalid symbol name" );
     check( maximum_supply.is_valid(), "invalid supply");
     check( maximum_supply.amount > 0, "max-supply must be positive");
 


### PR DESCRIPTION
Remove duplicated is valid check for eosio.token `create` action

Asset.is_valid already checks that the symbol is valid